### PR TITLE
build(make): VERSION bump에 10진 자리올림 적용

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ bump:
 	MAJOR=$$(echo $$CUR | cut -d. -f1); \
 	MINOR=$$(echo $$CUR | cut -d. -f2); \
 	PATCH=$$(echo $$CUR | cut -d. -f3); \
-	NEW="$$MAJOR.$$MINOR.$$((PATCH + 1))"; \
+	PATCH=$$((PATCH + 1)); \
+	if [ $$PATCH -ge 10 ]; then PATCH=0; MINOR=$$((MINOR + 1)); fi; \
+	if [ $$MINOR -ge 10 ]; then MINOR=0; MAJOR=$$((MAJOR + 1)); fi; \
+	NEW="$$MAJOR.$$MINOR.$$PATCH"; \
 	echo "$$NEW" > VERSION; \
 	sed -i 's/newTag: ".*"/newTag: "'$$NEW'"/' deploy/overlays/dev/kustomization.yaml; \
 	sed -i 's/newTag: ".*"/newTag: "'$$NEW'"/' deploy/overlays/prod/kustomization.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ bump:
 	MINOR=$$(echo $$CUR | cut -d. -f2); \
 	PATCH=$$(echo $$CUR | cut -d. -f3); \
 	PATCH=$$((PATCH + 1)); \
-	if [ $$PATCH -ge 10 ]; then PATCH=0; MINOR=$$((MINOR + 1)); fi; \
-	if [ $$MINOR -ge 10 ]; then MINOR=0; MAJOR=$$((MAJOR + 1)); fi; \
+	if [ "$$PATCH" -ge 10 ]; then PATCH=0; MINOR=$$((MINOR + 1)); fi; \
+	if [ "$$MINOR" -ge 10 ]; then MINOR=0; MAJOR=$$((MAJOR + 1)); fi; \
 	NEW="$$MAJOR.$$MINOR.$$PATCH"; \
 	echo "$$NEW" > VERSION; \
 	sed -i 's/newTag: ".*"/newTag: "'$$NEW'"/' deploy/overlays/dev/kustomization.yaml; \


### PR DESCRIPTION
## 개요

`make bump`가 patch 자리만 +1하여 `0.1.9` 다음이 `0.1.10`이 되던 동작을 10진 자리올림 규칙으로 교체한다. patch가 9를 넘으면 0으로 리셋 후 minor를 +1하고, minor가 9를 넘으면 0으로 리셋 후 major를 +1한다.

## 변경 범위

- `Makefile`의 `bump` 타깃만 수정, 다른 타깃과 기존 파일은 그대로 유지

## 검증

로컬에서 3개(Major/Minor/Patch) 케이스 모두 PASS 확인을 완료함.

- `0.1.5` → `0.1.6`
- `0.1.9` → `0.2.0`
- `0.9.9` → `1.0.0`

`deploy/overlays/{dev,prod}/kustomization.yaml`의 image tag도 동일 규칙으로 갱신됨을 확인함.

Closes #8
Refs #7
