### PR TITLE
feat(gpuobs): Phase 2 — NVML device 단위 메트릭 수집 및 발행

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@
 FROM golang:1.22-bookworm AS builder
 ARG TARGETARCH=amd64
 ARG TARGET_AGENT=netobs-agent
+# CGO_ENABLED 기본값은 0(정적 바이너리). go-nvml처럼 CGO `import "C"` 경로로 구현된
+# 의존성을 쓰는 에이전트(gpuobs-agent)는 Makefile의 CGO_<agent> 매핑에서 1을 전달한다.
+ARG CGO_ENABLED=0
 
 WORKDIR /src
 
@@ -20,7 +23,7 @@ COPY internal ./internal
 COPY bpf ./bpf
 COPY configs ./configs
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} \
     go build -o /out/${TARGET_AGENT} ./cmd/${TARGET_AGENT}
 
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ KUSTOMIZE ?= kubectl kustomize
 #   1) AGENTS에 이름 추가
 #   2) PORT_<name>에 기본 포트 할당
 #   3) 선행 태스크(BPF 재생성 등)가 필요하면 PREREQS_<name>에 타깃명 기입
+#   4) CGO_<name>에 0(정적 바이너리) 또는 1(CGO 의존성 존재) 할당
 # 이후 build-<name>, image-build-<name>, image-push-<name>이 자동으로 매치된다.
 # ============================================================================
 AGENTS := netobs-agent gpuobs-agent
@@ -18,6 +19,11 @@ PORT_netobs-agent := 9810
 PORT_gpuobs-agent := 9820
 
 PREREQS_netobs-agent := generate
+
+# go-nvml v0.13.x는 NVML 호출을 CGO `import "C"`로 구현해 CGO 비활성 빌드에서 심볼이
+# 해석되지 않는다. gpuobs-agent만 CGO=1로, netobs-agent는 기존 정적 바이너리 속성을 유지한다.
+CGO_netobs-agent := 0
+CGO_gpuobs-agent := 1
 
 # ============================================================================
 # Overlay registry — <agent-domain>-<rollout-stage> 형식
@@ -80,12 +86,13 @@ generate:
 
 build-%-agent: $$(PREREQS_$$*-agent)
 	go fmt ./...
-	go build -o ./bin/$*-agent ./cmd/$*-agent
+	CGO_ENABLED=$(CGO_$*-agent) go build -o ./bin/$*-agent ./cmd/$*-agent
 
 image-build-%-agent:
 	docker build \
 		--build-arg TARGET_AGENT=$*-agent \
 		--build-arg AGENT_PORT=$(PORT_$*-agent) \
+		--build-arg CGO_ENABLED=$(CGO_$*-agent) \
 		-t $*-agent:$(VERSION) .
 
 image-push-%-agent: image-build-%-agent

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ sudo ./bin/netobs-agent -listen :9810 -print-events=true
 |---|---|---|---|
 | `LISTEN_ADDR` | `-listen` | `:9820` | HTTP listen address |
 | `NODE_NAME` | `-node-name` | *(hostname)* | Observed Kubernetes node name |
-
-Additional variables (`GPU_POLL_INTERVAL`, `GPU_METRICS_ENABLED`) arrive in Phase 2 when NVML polling is introduced.
+| `GPU_POLL_INTERVAL` | `-poll-interval` | `5s` | NVML device polling interval; must be > 0 |
+| `GPU_METRICS_ENABLED` | `-gpu-metrics` | `true` | Emit `gpuobs_device_*` metrics; set false to skip device polling entirely |
 
 ## Versioning
 
@@ -167,11 +167,18 @@ Both agents expose the same endpoints (netobs: `:9810`, gpuobs: `:9820`).
 
 ### gpuobs
 
-Phase 1 exposes only a build-info gauge. Device-level gauges (utilization, memory, temperature, power) arrive in Phase 2 and per-pod attribution in Phase 3.
+Device-level gauges are sampled from NVML every `GPU_POLL_INTERVAL` (default 5s). Per-pod attribution arrives in Phase 3.
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `gpuobs_agent_info` | Gauge | `version` | Static agent info, value always 1 |
+| `gpuobs_device_utilization_percent` | Gauge | `node`, `gpu_uuid`, `gpu_index`, `gpu_model` | GPU compute utilization (0-100) |
+| `gpuobs_device_memory_used_bytes` | Gauge | `node`, `gpu_uuid`, `gpu_index`, `gpu_model` | GPU memory used (bytes) |
+| `gpuobs_device_memory_total_bytes` | Gauge | `node`, `gpu_uuid`, `gpu_index`, `gpu_model` | GPU memory total capacity (bytes) |
+| `gpuobs_device_temperature_celsius` | Gauge | `node`, `gpu_uuid`, `gpu_index`, `gpu_model` | GPU temperature (°C) |
+| `gpuobs_device_power_usage_watts` | Gauge | `node`, `gpu_uuid`, `gpu_index`, `gpu_model` | GPU power draw (watts) |
+
+On NVML initialization failure (non-GPU node, driver missing) or when `GPU_METRICS_ENABLED=false`, the collector logs a warning and skips device polling; `gpuobs_device_*` series are not emitted, and `/healthz`·`/readyz` continue to return 200.
 
 ## Notes
 

--- a/cmd/gpuobs-agent/main.go
+++ b/cmd/gpuobs-agent/main.go
@@ -15,6 +15,7 @@ import (
 	"netobs/internal/gpuobs/collector"
 	"netobs/internal/gpuobs/config"
 	"netobs/internal/gpuobs/metrics"
+	"netobs/internal/gpuobs/nvml"
 	"netobs/internal/server"
 )
 
@@ -53,9 +54,17 @@ func main() {
 		}
 	}()
 
-	// Phase 1 collector는 placeholder로, ctx가 취소되면 즉시 종료된다.
-	// Phase 2에서 NVML 폴링 루프로 대체된다.
-	col := collector.New()
+	// NVML 초기화. non-GPU 노드나 driver 미설치 환경에서는 실패할 수 있으며, 그 경우
+	// warn 로그만 남기고 nil 핸들을 주입한다. collector가 graceful disable 경로로
+	// 분기해 /healthz·/readyz=200을 유지한 채 바이너리 기동을 이어간다.
+	var nv nvml.NVML
+	if n, err := nvml.Init(); err != nil {
+		log.Printf("warn: nvml init failed, gpuobs collector disabled: %v", err)
+	} else {
+		nv = n
+	}
+
+	col := collector.New(nv, cfg)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- col.Run(ctx, func() {

--- a/cmd/gpuobs-agent/main.go
+++ b/cmd/gpuobs-agent/main.go
@@ -54,14 +54,17 @@ func main() {
 		}
 	}()
 
-	// NVML 초기화. non-GPU 노드나 driver 미설치 환경에서는 실패할 수 있으며, 그 경우
-	// warn 로그만 남기고 nil 핸들을 주입한다. collector가 graceful disable 경로로
-	// 분기해 /healthz·/readyz=200을 유지한 채 바이너리 기동을 이어간다.
+	// NVML 초기화는 수집이 활성화된 경우에만 시도한다. GPU_METRICS_ENABLED=false 환경에서는
+	// libnvidia-ml.so.1 로드 자체를 건너뛰어 불필요한 초기화 비용과 실패 로그를 제거한다.
+	// 활성화된 상태에서 non-GPU 노드나 driver 미설치로 Init이 실패하면 warn 로그만 남기고
+	// nil 핸들을 주입해, collector가 graceful disable 경로로 분기하도록 한다.
 	var nv nvml.NVML
-	if n, err := nvml.Init(); err != nil {
-		log.Printf("warn: nvml init failed, gpuobs collector disabled: %v", err)
-	} else {
-		nv = n
+	if cfg.GPUMetricsEnabled {
+		if n, err := nvml.Init(); err != nil {
+			log.Printf("warn: nvml init failed, gpuobs collector disabled: %v", err)
+		} else {
+			nv = n
+		}
 	}
 
 	col := collector.New(nv, cfg)

--- a/configs/gpuobs-agent.env.example
+++ b/configs/gpuobs-agent.env.example
@@ -3,3 +3,9 @@ LISTEN_ADDR=:9820
 
 # 관찰 대상 노드 이름 (비워두면 hostname 사용)
 NODE_NAME=
+
+# NVML device 폴링 주기 (기본값 5s, >0 이어야 함)
+GPU_POLL_INTERVAL=5s
+
+# per-device gpuobs_device_* 메트릭 발행 여부 (기본값 true)
+GPU_METRICS_ENABLED=true

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
+	github.com/NVIDIA/go-nvml v0.13.0-1
 	github.com/cilium/ebpf v0.17.1
 	github.com/prometheus/client_golang v1.20.5
 	k8s.io/api v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
+github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -104,8 +106,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/gpuobs/collector/collector.go
+++ b/internal/gpuobs/collector/collector.go
@@ -37,18 +37,21 @@ func (c *Collector) Run(ctx context.Context, onReady func()) error {
 		<-ctx.Done()
 		return nil
 	}
+
+	// non-nil NVML 핸들을 받은 이상 lifecycle은 collector가 소유한다.
+	// flag 기반 disable 경로에서도 defer가 먼저 등록되어 Shutdown이 보장된다.
+	defer func() {
+		if err := c.nvml.Shutdown(); err != nil {
+			log.Printf("nvml shutdown: %v", err)
+		}
+	}()
+
 	if !c.cfg.GPUMetricsEnabled {
 		log.Printf("gpuobs collector disabled: GPU_METRICS_ENABLED=false")
 		signalReady(onReady)
 		<-ctx.Done()
 		return nil
 	}
-
-	defer func() {
-		if err := c.nvml.Shutdown(); err != nil {
-			log.Printf("nvml shutdown: %v", err)
-		}
-	}()
 
 	// 초기 1회 폴링으로 기동 직후 /metrics를 채운 뒤 readiness를 올린다.
 	c.pollOnce()

--- a/internal/gpuobs/collector/collector.go
+++ b/internal/gpuobs/collector/collector.go
@@ -15,8 +15,9 @@ import (
 
 // Collector는 NVML 폴링 루프를 소유한다.
 type Collector struct {
-	nvml nvml.NVML
-	cfg  config.Config
+	nvml    nvml.NVML
+	cfg     config.Config
+	devices []nvml.Device
 }
 
 // New는 NVML 핸들과 Config를 받아 Collector를 구성한다.
@@ -28,8 +29,11 @@ func New(nv nvml.NVML, cfg config.Config) *Collector {
 // Run은 수집 루프를 실행한다.
 //
 //   - NVML 불가 또는 메트릭 비활성화 시: warn 로그 후 ctx.Done 까지 대기
-//   - 정상 경로: 최초 1회 pollOnce → readiness 신호 → cfg.GPUPollInterval 주기로 폴링
+//   - 정상 경로: Run 시작 시 device 핸들을 1회 discover → 초기 pollOnce → readiness 신호 →
+//     cfg.GPUPollInterval 주기로 캐시된 device 슬라이스만 반복 폴링
 //   - ctx 취소 시 NVML Shutdown까지 수행한 뒤 반환
+//
+// device hot-plug는 Phase 2 비목표이며, discover 이후 추가된 device는 다음 기동까지 인식되지 않는다.
 func (c *Collector) Run(ctx context.Context, onReady func()) error {
 	if c.nvml == nil {
 		log.Printf("gpuobs collector disabled: NVML unavailable")
@@ -53,6 +57,9 @@ func (c *Collector) Run(ctx context.Context, onReady func()) error {
 		return nil
 	}
 
+	// device 핸들과 정적 속성을 1회 discover해 이후 폴링에서 재조회가 일어나지 않도록 한다.
+	c.devices = c.discover()
+
 	// 초기 1회 폴링으로 기동 직후 /metrics를 채운 뒤 readiness를 올린다.
 	c.pollOnce()
 	signalReady(onReady)
@@ -70,23 +77,34 @@ func (c *Collector) Run(ctx context.Context, onReady func()) error {
 	}
 }
 
-// pollOnce는 현재 시점의 모든 device 스냅샷을 읽어 metrics로 전달한다.
-// 한 device에서 실패해도 나머지 device 폴링은 계속한다.
-func (c *Collector) pollOnce() {
+// discover는 Run 진입 시 1회 실행되어 NVML device 개수를 읽고 각 index의 핸들을 얻는다.
+// 개별 device의 핸들 획득이 실패하면 해당 device만 건너뛰고 계속 진행한다.
+func (c *Collector) discover() []nvml.Device {
 	count, err := c.nvml.DeviceCount()
 	if err != nil {
 		log.Printf("gpuobs: device count: %v", err)
-		return
+		return nil
 	}
+	devices := make([]nvml.Device, 0, count)
 	for i := uint(0); i < count; i++ {
 		dev, err := c.nvml.Device(i)
 		if err != nil {
 			log.Printf("gpuobs: device idx=%d: %v", i, err)
 			continue
 		}
+		devices = append(devices, dev)
+	}
+	return devices
+}
+
+// pollOnce는 캐시된 device 핸들마다 Snapshot을 읽어 metrics로 전달한다.
+// 한 device에서 실패해도 나머지 device 폴링은 계속한다.
+func (c *Collector) pollOnce() {
+	for _, dev := range c.devices {
 		snap, err := dev.Snapshot()
 		if err != nil {
-			log.Printf("gpuobs: snapshot idx=%d: %v", i, err)
+			// wrapErr가 이미 idx 컨텍스트를 포함한다.
+			log.Printf("gpuobs: snapshot: %v", err)
 			continue
 		}
 		metrics.Record(c.cfg.NodeName, snap)

--- a/internal/gpuobs/collector/collector.go
+++ b/internal/gpuobs/collector/collector.go
@@ -1,30 +1,98 @@
+// Package collector는 gpuobs의 NVML 폴링 루프를 소유한다.
+// NVML 핸들이 없거나 메트릭이 비활성화된 경우 수집을 건너뛰고 ctx 종료까지 대기해,
+// non-GPU 노드에서도 바이너리와 health/ready 응답이 유지되도록 한다.
 package collector
 
-import "context"
+import (
+	"context"
+	"log"
+	"time"
 
-// Collector는 gpuobs의 수집 루프를 소유한다.
-// Phase 1의 placeholder는 상태가 없으며, Phase 2에서 NVML 핸들과 폴링 주기가
-// 필드로 추가된다.
-type Collector struct{}
+	"netobs/internal/gpuobs/config"
+	"netobs/internal/gpuobs/metrics"
+	"netobs/internal/gpuobs/nvml"
+)
 
-// New는 기본 Collector를 생성한다.
-// Phase 2에서 NVML 인터페이스와 Config 의존성을 주입 받도록 시그니처가 확장된다.
-func New() *Collector {
-	return &Collector{}
+// Collector는 NVML 폴링 루프를 소유한다.
+type Collector struct {
+	nvml nvml.NVML
+	cfg  config.Config
+}
+
+// New는 NVML 핸들과 Config를 받아 Collector를 구성한다.
+// nvml이 nil이어도 생성은 성공하며, Run 시점에 graceful disable 경로로 분기된다.
+func New(nv nvml.NVML, cfg config.Config) *Collector {
+	return &Collector{nvml: nv, cfg: cfg}
 }
 
 // Run은 수집 루프를 실행한다.
-// Phase 1 placeholder 동작은 다음과 같다.
 //
-//   - 진입 직후 onReady()를 호출해 readiness를 true로 전환시킴
-//   - ctx가 취소될 때까지 블록
-//   - 종료 시 nil 반환
-//
-// onReady는 nil이어도 안전하며, 그 경우 호출이 생략된다.
+//   - NVML 불가 또는 메트릭 비활성화 시: warn 로그 후 ctx.Done 까지 대기
+//   - 정상 경로: 최초 1회 pollOnce → readiness 신호 → cfg.GPUPollInterval 주기로 폴링
+//   - ctx 취소 시 NVML Shutdown까지 수행한 뒤 반환
 func (c *Collector) Run(ctx context.Context, onReady func()) error {
+	if c.nvml == nil {
+		log.Printf("gpuobs collector disabled: NVML unavailable")
+		signalReady(onReady)
+		<-ctx.Done()
+		return nil
+	}
+	if !c.cfg.GPUMetricsEnabled {
+		log.Printf("gpuobs collector disabled: GPU_METRICS_ENABLED=false")
+		signalReady(onReady)
+		<-ctx.Done()
+		return nil
+	}
+
+	defer func() {
+		if err := c.nvml.Shutdown(); err != nil {
+			log.Printf("nvml shutdown: %v", err)
+		}
+	}()
+
+	// 초기 1회 폴링으로 기동 직후 /metrics를 채운 뒤 readiness를 올린다.
+	c.pollOnce()
+	signalReady(onReady)
+
+	t := time.NewTicker(c.cfg.GPUPollInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			c.pollOnce()
+		}
+	}
+}
+
+// pollOnce는 현재 시점의 모든 device 스냅샷을 읽어 metrics로 전달한다.
+// 한 device에서 실패해도 나머지 device 폴링은 계속한다.
+func (c *Collector) pollOnce() {
+	count, err := c.nvml.DeviceCount()
+	if err != nil {
+		log.Printf("gpuobs: device count: %v", err)
+		return
+	}
+	for i := uint(0); i < count; i++ {
+		dev, err := c.nvml.Device(i)
+		if err != nil {
+			log.Printf("gpuobs: device idx=%d: %v", i, err)
+			continue
+		}
+		snap, err := dev.Snapshot()
+		if err != nil {
+			log.Printf("gpuobs: snapshot idx=%d: %v", i, err)
+			continue
+		}
+		metrics.Record(c.cfg.NodeName, snap)
+	}
+}
+
+// signalReady는 onReady가 nil이어도 호출 가능하도록 감싼다.
+func signalReady(onReady func()) {
 	if onReady != nil {
 		onReady()
 	}
-	<-ctx.Done()
-	return nil
 }

--- a/internal/gpuobs/collector/collector_test.go
+++ b/internal/gpuobs/collector/collector_test.go
@@ -131,8 +131,9 @@ func TestRun_FlagDisabledSkipsPolling(t *testing.T) {
 	if got := dev.snapCallCount(); got != 0 {
 		t.Fatalf("disabled path must not poll; got %d snapshot calls", got)
 	}
-	if got := fake.shutdownCallCount(); got != 0 {
-		t.Fatalf("disabled path must not call Shutdown; got %d", got)
+	// non-nil NVML 핸들을 받은 이상 disable 경로에서도 collector가 Shutdown을 보장해야 한다.
+	if got := fake.shutdownCallCount(); got != 1 {
+		t.Fatalf("disabled path must still release NVML; expected 1 Shutdown call, got %d", got)
 	}
 }
 

--- a/internal/gpuobs/collector/collector_test.go
+++ b/internal/gpuobs/collector/collector_test.go
@@ -1,0 +1,188 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"netobs/internal/gpuobs/config"
+	"netobs/internal/gpuobs/nvml"
+	"netobs/internal/gpuobs/types"
+)
+
+// fakeNVML은 nvml.NVML의 테스트용 구현이며, 호출 횟수와 사전에 지정된 디바이스 맵을 통해
+// collector 동작을 검증 가능한 상태로 관찰한다.
+type fakeNVML struct {
+	mu            sync.Mutex
+	count         uint
+	countErr      error
+	devices       map[uint]*fakeDevice
+	shutdownCalls int
+}
+
+func (f *fakeNVML) DeviceCount() (uint, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.count, f.countErr
+}
+
+func (f *fakeNVML) Device(i uint) (nvml.Device, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	d, ok := f.devices[i]
+	if !ok {
+		return nil, errors.New("unknown device")
+	}
+	return d, nil
+}
+
+func (f *fakeNVML) Shutdown() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.shutdownCalls++
+	return nil
+}
+
+func (f *fakeNVML) shutdownCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.shutdownCalls
+}
+
+type fakeDevice struct {
+	mu          sync.Mutex
+	info        types.GPUDevice
+	snapshot    types.GPUSnapshot
+	snapshotErr error
+	snapCalls   int
+}
+
+func (d *fakeDevice) Info() (types.GPUDevice, error) { return d.info, nil }
+
+func (d *fakeDevice) Snapshot() (types.GPUSnapshot, error) {
+	d.mu.Lock()
+	d.snapCalls++
+	d.mu.Unlock()
+	return d.snapshot, d.snapshotErr
+}
+
+func (d *fakeDevice) RunningProcesses() ([]types.GPUProcess, error) { return nil, nil }
+
+func (d *fakeDevice) snapCallCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.snapCalls
+}
+
+// waitReady는 onReady가 신호될 때까지 대기하며 타임아웃 시 테스트를 실패 처리한다.
+func waitReady(t *testing.T, readyCh <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-readyCh:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("onReady not signaled within timeout")
+	}
+}
+
+func TestRun_NilNVMLGracefullyDisables(t *testing.T) {
+	cfg := config.Config{GPUMetricsEnabled: true, GPUPollInterval: 10 * time.Millisecond, NodeName: "n"}
+	c := New(nil, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readyCh := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Run(ctx, func() { readyCh <- struct{}{} })
+	}()
+
+	waitReady(t, readyCh)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+func TestRun_FlagDisabledSkipsPolling(t *testing.T) {
+	dev := &fakeDevice{info: types.GPUDevice{Index: 0, UUID: "u0"}}
+	fake := &fakeNVML{count: 1, devices: map[uint]*fakeDevice{0: dev}}
+	cfg := config.Config{GPUMetricsEnabled: false, GPUPollInterval: 10 * time.Millisecond, NodeName: "n"}
+	c := New(fake, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readyCh := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Run(ctx, func() { readyCh <- struct{}{} })
+	}()
+
+	waitReady(t, readyCh)
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := dev.snapCallCount(); got != 0 {
+		t.Fatalf("disabled path must not poll; got %d snapshot calls", got)
+	}
+	if got := fake.shutdownCallCount(); got != 0 {
+		t.Fatalf("disabled path must not call Shutdown; got %d", got)
+	}
+}
+
+func TestRun_HappyPathPollsAndShutsDown(t *testing.T) {
+	dev0 := &fakeDevice{info: types.GPUDevice{Index: 0, UUID: "u0"}, snapshot: types.GPUSnapshot{UtilizationPct: 42}}
+	dev1 := &fakeDevice{info: types.GPUDevice{Index: 1, UUID: "u1"}, snapshot: types.GPUSnapshot{UtilizationPct: 77}}
+	fake := &fakeNVML{count: 2, devices: map[uint]*fakeDevice{0: dev0, 1: dev1}}
+	cfg := config.Config{GPUMetricsEnabled: true, GPUPollInterval: 10 * time.Millisecond, NodeName: "n"}
+	c := New(fake, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	readyCh := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Run(ctx, func() { readyCh <- struct{}{} })
+	}()
+
+	waitReady(t, readyCh)
+	// ready 직후 초기 1회 폴링이 완료되어 있어야 한다.
+	if got := dev0.snapCallCount(); got < 1 {
+		t.Fatalf("expected >=1 snapshot call on dev0 after ready; got %d", got)
+	}
+
+	// ticker 추가 폴링 대기 (~30ms ≈ 3 tick)
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := dev1.snapCallCount(); got < 2 {
+		t.Fatalf("expected >=2 snapshot calls on dev1 after ticker; got %d", got)
+	}
+	if got := fake.shutdownCallCount(); got != 1 {
+		t.Fatalf("expected Shutdown called exactly once on ctx cancel; got %d", got)
+	}
+}
+
+func TestPollOnce_PerDeviceErrorContinues(t *testing.T) {
+	dev0 := &fakeDevice{info: types.GPUDevice{Index: 0, UUID: "u0"}}
+	dev1 := &fakeDevice{info: types.GPUDevice{Index: 1, UUID: "u1"}, snapshotErr: errors.New("boom")}
+	dev2 := &fakeDevice{info: types.GPUDevice{Index: 2, UUID: "u2"}}
+	fake := &fakeNVML{count: 3, devices: map[uint]*fakeDevice{0: dev0, 1: dev1, 2: dev2}}
+	cfg := config.Config{GPUMetricsEnabled: true, NodeName: "n"}
+	c := New(fake, cfg)
+
+	c.pollOnce()
+
+	if got := dev0.snapCallCount(); got != 1 {
+		t.Errorf("dev0 should have been polled once; got %d", got)
+	}
+	if got := dev2.snapCallCount(); got != 1 {
+		t.Errorf("dev2 should be polled after dev1 error; got %d", got)
+	}
+}

--- a/internal/gpuobs/collector/collector_test.go
+++ b/internal/gpuobs/collector/collector_test.go
@@ -86,6 +86,36 @@ func waitReady(t *testing.T, readyCh <-chan struct{}) {
 	}
 }
 
+// waitDone은 Run goroutine이 반환할 때까지 대기하며 타임아웃 시 테스트를 실패 처리한다.
+// 단순 `<-done`을 쓰면 Run이 반환하지 못하는 결함이 있을 때 테스트가 영구 hang된다.
+func waitDone(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// waitUntil은 check가 true를 반환할 때까지 짧게 폴링하며, deadline 내에 만족되지 않으면
+// 테스트를 실패 처리한다. 고정 time.Sleep 대신 사용해 CI 스케줄링 지연에 강건해진다.
+func waitUntil(t *testing.T, timeout time.Duration, check func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !check() {
+		t.Fatal(msg)
+	}
+}
+
 func TestRun_NilNVMLGracefullyDisables(t *testing.T) {
 	cfg := config.Config{GPUMetricsEnabled: true, GPUPollInterval: 10 * time.Millisecond, NodeName: "n"}
 	c := New(nil, cfg)
@@ -99,15 +129,7 @@ func TestRun_NilNVMLGracefullyDisables(t *testing.T) {
 
 	waitReady(t, readyCh)
 	cancel()
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Run did not return after ctx cancel")
-	}
+	waitDone(t, done)
 }
 
 func TestRun_FlagDisabledSkipsPolling(t *testing.T) {
@@ -124,9 +146,11 @@ func TestRun_FlagDisabledSkipsPolling(t *testing.T) {
 	}()
 
 	waitReady(t, readyCh)
+	// disable 경로라 폴링이 일어나지 않아야 한다. ticker 주기 몇 번 분량만 대기해
+	// "disable 의도와 달리 폴링이 발생하지 않음"을 확인한다.
 	time.Sleep(30 * time.Millisecond)
 	cancel()
-	<-done
+	waitDone(t, done)
 
 	if got := dev.snapCallCount(); got != 0 {
 		t.Fatalf("disabled path must not poll; got %d snapshot calls", got)
@@ -157,14 +181,15 @@ func TestRun_HappyPathPollsAndShutsDown(t *testing.T) {
 		t.Fatalf("expected >=1 snapshot call on dev0 after ready; got %d", got)
 	}
 
-	// ticker 추가 폴링 대기 (~30ms ≈ 3 tick)
-	time.Sleep(30 * time.Millisecond)
-	cancel()
-	<-done
+	// ticker 기반 추가 폴링이 관측될 때까지 deadline 내에서 반복 확인한다.
+	// 고정 time.Sleep보다 CI 부하에 강건하다.
+	waitUntil(t, 300*time.Millisecond, func() bool {
+		return dev1.snapCallCount() >= 2
+	}, "expected >=2 snapshot calls on dev1 within timeout")
 
-	if got := dev1.snapCallCount(); got < 2 {
-		t.Fatalf("expected >=2 snapshot calls on dev1 after ticker; got %d", got)
-	}
+	cancel()
+	waitDone(t, done)
+
 	if got := fake.shutdownCallCount(); got != 1 {
 		t.Fatalf("expected Shutdown called exactly once on ctx cancel; got %d", got)
 	}
@@ -177,6 +202,8 @@ func TestPollOnce_PerDeviceErrorContinues(t *testing.T) {
 	fake := &fakeNVML{count: 3, devices: map[uint]*fakeDevice{0: dev0, 1: dev1, 2: dev2}}
 	cfg := config.Config{GPUMetricsEnabled: true, NodeName: "n"}
 	c := New(fake, cfg)
+	// Run을 거치지 않고 pollOnce만 단독 검증하므로 discover가 채워야 할 devices를 직접 주입한다.
+	c.devices = []nvml.Device{dev0, dev1, dev2}
 
 	c.pollOnce()
 

--- a/internal/gpuobs/collector/doc.go
+++ b/internal/gpuobs/collector/doc.go
@@ -1,5 +1,0 @@
-// Package collector는 gpuobs의 수집 루프를 정의한다.
-// Phase 1에서는 실제 NVML 폴링 없이 기동 직후 ready 신호만 내고 context 취소까지
-// 대기하는 placeholder 동작만 수행한다. Phase 2에서 NVML 인터페이스와 ticker 기반
-// 폴링 루프가 이 자리에 들어온다.
-package collector

--- a/internal/gpuobs/config/config.go
+++ b/internal/gpuobs/config/config.go
@@ -6,26 +6,38 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 // Config는 gpuobs 에이전트의 실행 시 설정을 담는다.
 type Config struct {
-	ListenAddr string
-	NodeName   string
+	ListenAddr        string
+	NodeName          string
+	GPUPollInterval   time.Duration
+	GPUMetricsEnabled bool
 }
 
 // Parse는 env와 CLI flag를 읽어 Config를 구성해 반환한다.
 // env가 기본값으로 들어가고 flag가 지정되면 그 값이 최종 값이 된다.
 // NodeName이 비어 있으면 os.Hostname 결과로 채워진다.
 func Parse() (Config, error) {
+	pollInterval, err := getenvDuration("GPU_POLL_INTERVAL", 5*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
-		ListenAddr: getenvDefault("LISTEN_ADDR", ":9820"),
-		NodeName:   getenvDefault("NODE_NAME", ""),
+		ListenAddr:        getenvDefault("LISTEN_ADDR", ":9820"),
+		NodeName:          getenvDefault("NODE_NAME", ""),
+		GPUPollInterval:   pollInterval,
+		GPUMetricsEnabled: getenvBool("GPU_METRICS_ENABLED", true),
 	}
 
 	fs := flag.NewFlagSet("gpuobs-agent", flag.ContinueOnError)
 	fs.StringVar(&cfg.ListenAddr, "listen", cfg.ListenAddr, "HTTP listen address for metrics and health endpoints")
 	fs.StringVar(&cfg.NodeName, "node-name", cfg.NodeName, "observed Kubernetes node name (defaults to hostname when empty)")
+	fs.DurationVar(&cfg.GPUPollInterval, "poll-interval", cfg.GPUPollInterval, "NVML polling interval for device snapshots")
+	fs.BoolVar(&cfg.GPUMetricsEnabled, "gpu-metrics", cfg.GPUMetricsEnabled, "emit per-device gpuobs_device_* metrics; disable to suppress device-level collection")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		// -h/-help 요청은 flag 패키지가 usage를 출력한 뒤 ErrHelp를 반환한다.
 		// 사용자 의도된 정상 경로이므로 exit 0으로 종료한다.
@@ -37,6 +49,10 @@ func Parse() (Config, error) {
 
 	if strings.TrimSpace(cfg.ListenAddr) == "" {
 		return Config{}, fmt.Errorf("listen address must not be empty")
+	}
+
+	if cfg.GPUPollInterval <= 0 {
+		return Config{}, fmt.Errorf("invalid -poll-interval: must be > 0")
 	}
 
 	if strings.TrimSpace(cfg.NodeName) == "" {
@@ -55,4 +71,24 @@ func getenvDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func getenvBool(key string, def bool) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if v == "" {
+		return def
+	}
+	return v == "1" || v == "true" || v == "yes" || v == "y"
+}
+
+func getenvDuration(key string, def time.Duration) (time.Duration, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration for %s: %q", key, v)
+	}
+	return d, nil
 }

--- a/internal/gpuobs/config/config.go
+++ b/internal/gpuobs/config/config.go
@@ -1,10 +1,13 @@
-// env가 기본값이 되고 CLI flag가 지정되면 그 값이 env를 덮어쓰는 순서를 따른다.
+// Package config는 gpuobs 에이전트의 실행 시 설정을 정의하며, env 값이 기본값이 되고
+// CLI flag가 지정되면 env를 덮어쓰는 순서를 따른다. env 형식 오류는 warn 로그를 남기고
+// 기본값으로 폴백해 flag가 여전히 최종 값을 덮어쓸 수 있게 한다.
 package config
 
 import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -19,12 +22,17 @@ type Config struct {
 }
 
 // Parse는 env와 CLI flag를 읽어 Config를 구성해 반환한다.
-// env가 기본값으로 들어가고 flag가 지정되면 그 값이 최종 값이 된다.
+// env 값이 기본값이 되고 CLI flag가 지정되면 env를 덮어쓴다. env가 형식 오류(예:
+// `GPU_POLL_INTERVAL`의 duration 파싱 실패)인 경우 warn 로그를 남기고 기본값으로 폴백해
+// -poll-interval 등 flag가 명시되면 그 값이 최종적으로 이기도록 한다. ConfigMap/DaemonSet
+// 오타는 warn 로그로 계속 드러나 완전히 숨겨지지 않는다.
 // NodeName이 비어 있으면 os.Hostname 결과로 채워진다.
 func Parse() (Config, error) {
 	pollInterval, err := getenvDuration("GPU_POLL_INTERVAL", 5*time.Second)
 	if err != nil {
-		return Config{}, err
+		// env 형식 오류는 "env < flag 우선순위" 를 끊지 않도록 warn 후 기본값으로 폴백한다.
+		// 이후 -poll-interval flag가 명시되면 그 값이 최종적으로 덮어쓴다.
+		log.Printf("warn: %v; using default %v", err, pollInterval)
 	}
 
 	cfg := Config{
@@ -82,6 +90,9 @@ func getenvBool(key string, def bool) bool {
 	return v == "1" || v == "true" || v == "yes" || v == "y"
 }
 
+// getenvDuration은 key env를 duration으로 파싱해 반환한다.
+// 형식 오류일 때는 호출자가 "env < flag 우선순위" 약속을 유지할 수 있도록 기본값과
+// 함께 에러를 돌려주어, 호출자가 warn 로그 후 폴백을 선택할 수 있게 한다.
 func getenvDuration(key string, def time.Duration) (time.Duration, error) {
 	v := strings.TrimSpace(os.Getenv(key))
 	if v == "" {
@@ -89,7 +100,7 @@ func getenvDuration(key string, def time.Duration) (time.Duration, error) {
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil {
-		return 0, fmt.Errorf("invalid duration for %s: %q", key, v)
+		return def, fmt.Errorf("invalid duration for %s: %q", key, v)
 	}
 	return d, nil
 }

--- a/internal/gpuobs/config/config.go
+++ b/internal/gpuobs/config/config.go
@@ -1,3 +1,4 @@
+// env가 기본값이 되고 CLI flag가 지정되면 그 값이 env를 덮어쓰는 순서를 따른다.
 package config
 
 import (

--- a/internal/gpuobs/config/doc.go
+++ b/internal/gpuobs/config/doc.go
@@ -1,5 +1,0 @@
-// Package config는 gpuobs 에이전트의 실행 시 설정을 정의한다.
-// env와 CLI flag 양쪽에서 값을 받을 수 있으며, CLI flag가 env를 덮어쓴다.
-// Phase 1에서는 ListenAddr과 NodeName 두 항목만 노출하며, 폴링 주기와
-// 카디널리티 토글 등은 Phase 2 이후에 추가된다.
-package config

--- a/internal/gpuobs/metrics/doc.go
+++ b/internal/gpuobs/metrics/doc.go
@@ -1,5 +1,0 @@
-// Package metrics는 gpuobs 에이전트가 Prometheus로 발행하는 지표를 정의한다.
-// Phase 1에서는 에이전트 기동 여부를 알리는 최소한의 info Gauge만 등록되며,
-// device 단위 Gauge 5종은 Phase 2에서 추가된다. gpuobs 전용 프리픽스 `gpuobs_`를
-// 사용해 netobs 지표(`netobs_*`)와 네임스페이스를 분리한다.
-package metrics

--- a/internal/gpuobs/metrics/metrics.go
+++ b/internal/gpuobs/metrics/metrics.go
@@ -82,18 +82,17 @@ func Register(reg prometheus.Registerer) {
 }
 
 // Record는 한 device의 현재 스냅샷을 모든 device gauge에 기록한다.
+// 인자 순서는 deviceLabels({node, gpu_uuid, gpu_index, gpu_model})와 정확히 일치해야 하며,
+// 매 호출 시 `prometheus.Labels` 맵 할당을 피하기 위해 `WithLabelValues`를 사용한다.
 // 라벨 카디널리티는 노드당 device 수(통상 ≤8)로 제한되어 별도 escape hatch는 두지 않는다.
 func Record(node string, snap types.GPUSnapshot) {
-	labels := prometheus.Labels{
-		"node":      node,
-		"gpu_uuid":  snap.Device.UUID,
-		"gpu_index": strconv.FormatUint(uint64(snap.Device.Index), 10),
-		"gpu_model": snap.Device.Model,
-	}
+	idx := strconv.FormatUint(uint64(snap.Device.Index), 10)
+	uuid := snap.Device.UUID
+	model := snap.Device.Model
 
-	deviceUtilization.With(labels).Set(float64(snap.UtilizationPct))
-	deviceMemoryUsed.With(labels).Set(float64(snap.MemoryUsedBytes))
-	deviceMemoryTotal.With(labels).Set(float64(snap.MemoryTotalBytes))
-	deviceTemperature.With(labels).Set(float64(snap.TemperatureC))
-	devicePower.With(labels).Set(snap.PowerUsageWatts)
+	deviceUtilization.WithLabelValues(node, uuid, idx, model).Set(float64(snap.UtilizationPct))
+	deviceMemoryUsed.WithLabelValues(node, uuid, idx, model).Set(float64(snap.MemoryUsedBytes))
+	deviceMemoryTotal.WithLabelValues(node, uuid, idx, model).Set(float64(snap.MemoryTotalBytes))
+	deviceTemperature.WithLabelValues(node, uuid, idx, model).Set(float64(snap.TemperatureC))
+	devicePower.WithLabelValues(node, uuid, idx, model).Set(snap.PowerUsageWatts)
 }

--- a/internal/gpuobs/metrics/metrics.go
+++ b/internal/gpuobs/metrics/metrics.go
@@ -1,6 +1,14 @@
+// Package metrics는 gpuobs 에이전트가 Prometheus로 발행하는 지표를 정의한다.
+// gpuobs 전용 프리픽스 `gpuobs_`를 써서 netobs 지표(`netobs_*`)와 네임스페이스를 분리한다.
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"netobs/internal/gpuobs/types"
+)
 
 // AgentVersion은 에이전트의 버전 문자열이며, Phase 4 릴리스에서 ldflags로 치환된다.
 // Phase 1에서는 "dev" 고정 문자열을 쓴다.
@@ -14,9 +22,78 @@ var agentInfo = prometheus.NewGauge(
 	},
 )
 
+// deviceLabels는 device 단위 gauge의 공통 라벨 세트다. UUID는 안정적 식별자,
+// index는 slot, model은 그래프 범주화, node는 클러스터 내 귀속에 쓴다.
+var deviceLabels = []string{"node", "gpu_uuid", "gpu_index", "gpu_model"}
+
+var (
+	deviceUtilization = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gpuobs_device_utilization_percent",
+			Help: "GPU compute utilization (0-100) sampled from NVML",
+		},
+		deviceLabels,
+	)
+
+	deviceMemoryUsed = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gpuobs_device_memory_used_bytes",
+			Help: "GPU memory used in bytes sampled from NVML",
+		},
+		deviceLabels,
+	)
+
+	deviceMemoryTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gpuobs_device_memory_total_bytes",
+			Help: "GPU memory total capacity in bytes sampled from NVML",
+		},
+		deviceLabels,
+	)
+
+	deviceTemperature = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gpuobs_device_temperature_celsius",
+			Help: "GPU temperature in Celsius sampled from NVML",
+		},
+		deviceLabels,
+	)
+
+	devicePower = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gpuobs_device_power_usage_watts",
+			Help: "GPU power draw in watts sampled from NVML",
+		},
+		deviceLabels,
+	)
+)
+
 // Register는 gpuobs 지표를 주어진 Prometheus Registerer에 등록한다.
-// Phase 1에서는 agent_info 하나만 등록되며 값은 항상 1이다.
 func Register(reg prometheus.Registerer) {
 	agentInfo.Set(1)
-	reg.MustRegister(agentInfo)
+	reg.MustRegister(
+		agentInfo,
+		deviceUtilization,
+		deviceMemoryUsed,
+		deviceMemoryTotal,
+		deviceTemperature,
+		devicePower,
+	)
+}
+
+// Record는 한 device의 현재 스냅샷을 모든 device gauge에 기록한다.
+// 라벨 카디널리티는 노드당 device 수(통상 ≤8)로 제한되어 별도 escape hatch는 두지 않는다.
+func Record(node string, snap types.GPUSnapshot) {
+	labels := prometheus.Labels{
+		"node":      node,
+		"gpu_uuid":  snap.Device.UUID,
+		"gpu_index": strconv.FormatUint(uint64(snap.Device.Index), 10),
+		"gpu_model": snap.Device.Model,
+	}
+
+	deviceUtilization.With(labels).Set(float64(snap.UtilizationPct))
+	deviceMemoryUsed.With(labels).Set(float64(snap.MemoryUsedBytes))
+	deviceMemoryTotal.With(labels).Set(float64(snap.MemoryTotalBytes))
+	deviceTemperature.With(labels).Set(float64(snap.TemperatureC))
+	devicePower.With(labels).Set(snap.PowerUsageWatts)
 }

--- a/internal/gpuobs/nvml/doc.go
+++ b/internal/gpuobs/nvml/doc.go
@@ -1,5 +1,0 @@
-// Package nvml은 NVIDIA Management Library 접근을 위한 gpuobs의 추상 인터페이스를 제공한다.
-// Phase 1에서는 인터페이스만 선언하며, 실제 go-nvml 기반 dlopen 구현은 Phase 2에서
-// 이 인터페이스를 만족하는 형태로 추가된다. 이 분리는 단위 테스트가 NVML을 mock으로
-// 대체해 non-GPU CI 환경에서도 collector 동작을 검증할 수 있게 하려는 목적이다.
-package nvml

--- a/internal/gpuobs/nvml/nvml.go
+++ b/internal/gpuobs/nvml/nvml.go
@@ -1,29 +1,148 @@
+// Package nvml은 NVIDIA Management Library 호출을 gpuobs 전용 인터페이스로 추상화하고,
+// go-nvml(libnvidia-ml.so.1 dlopen) 기반 구현을 함께 제공한다. 인터페이스를 분리해둔
+// 덕에 테스트는 fake NVML을 주입해 non-GPU 환경에서도 collector 동작을 검증할 수 있다.
 package nvml
 
-import "netobs/internal/gpuobs/types"
+import (
+	"fmt"
 
-// NVML은 NVIDIA Management Library 호출을 추상화한 인터페이스이다.
-// Phase 2에서 go-nvml dlopen 기반 구현이 이 인터페이스를 만족시킨다.
+	gonvml "github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"netobs/internal/gpuobs/types"
+)
+
+// NVML은 NVIDIA Management Library 호출을 추상화한 인터페이스다.
 type NVML interface {
-	// DeviceCount는 사용 가능한 GPU device의 개수를 반환한다.
 	DeviceCount() (uint, error)
-
-	// Device는 주어진 index의 device 핸들을 반환한다.
 	Device(index uint) (Device, error)
-
-	// Shutdown은 NVML 라이브러리를 해제한다.
 	Shutdown() error
 }
 
 // Device는 개별 GPU device에 대한 읽기 전용 접근을 제공한다.
 type Device interface {
-	// Info는 device의 정적 식별 정보를 반환한다.
 	Info() (types.GPUDevice, error)
-
-	// Snapshot은 현재 시점의 device 상태를 반환한다.
 	Snapshot() (types.GPUSnapshot, error)
-
-	// RunningProcesses는 이 device에서 실행 중인 프로세스 목록을 반환한다.
-	// Phase 3의 Pod 귀속 단계에서 입력으로 사용된다.
 	RunningProcesses() ([]types.GPUProcess, error)
+}
+
+// Init은 NVML 라이브러리(libnvidia-ml.so.1)를 런타임에 dlopen하고 초기화한다.
+// 실패 시 에러를 반환하므로 호출자(collector)가 warn 로그 후 graceful disable을
+// 선택할 수 있으며, non-GPU 노드에서도 바이너리가 기동을 멈추지 않는다.
+func Init() (NVML, error) {
+	if err := nvmlErr("nvml init", gonvml.Init()); err != nil {
+		return nil, err
+	}
+	return &nvmlImpl{}, nil
+}
+
+// nvmlErr은 NVML 반환값을 Go 에러로 래핑하며 SUCCESS는 nil을 반환한다.
+func nvmlErr(op string, ret gonvml.Return) error {
+	if ret == gonvml.SUCCESS {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", op, gonvml.ErrorString(ret))
+}
+
+type nvmlImpl struct{}
+
+func (n *nvmlImpl) DeviceCount() (uint, error) {
+	count, ret := gonvml.DeviceGetCount()
+	if err := nvmlErr("device count", ret); err != nil {
+		return 0, err
+	}
+	return uint(count), nil
+}
+
+func (n *nvmlImpl) Device(index uint) (Device, error) {
+	handle, ret := gonvml.DeviceGetHandleByIndex(int(index))
+	if err := nvmlErr(fmt.Sprintf("device handle idx=%d", index), ret); err != nil {
+		return nil, err
+	}
+	return &deviceImpl{handle: handle, index: index}, nil
+}
+
+func (n *nvmlImpl) Shutdown() error {
+	return nvmlErr("nvml shutdown", gonvml.Shutdown())
+}
+
+type deviceImpl struct {
+	handle gonvml.Device
+	index  uint
+}
+
+// wrapErr는 device 호출 에러에 device index 컨텍스트를 덧붙여 래핑한다.
+func (d *deviceImpl) wrapErr(op string, ret gonvml.Return) error {
+	if ret == gonvml.SUCCESS {
+		return nil
+	}
+	return fmt.Errorf("%s idx=%d: %s", op, d.index, gonvml.ErrorString(ret))
+}
+
+func (d *deviceImpl) Info() (types.GPUDevice, error) {
+	uuid, ret := d.handle.GetUUID()
+	if err := d.wrapErr("device uuid", ret); err != nil {
+		return types.GPUDevice{}, err
+	}
+	name, ret := d.handle.GetName()
+	if err := d.wrapErr("device name", ret); err != nil {
+		return types.GPUDevice{}, err
+	}
+	return types.GPUDevice{
+		Index: d.index,
+		UUID:  uuid,
+		Model: name,
+	}, nil
+}
+
+func (d *deviceImpl) Snapshot() (types.GPUSnapshot, error) {
+	info, err := d.Info()
+	if err != nil {
+		return types.GPUSnapshot{}, err
+	}
+
+	util, ret := d.handle.GetUtilizationRates()
+	if err := d.wrapErr("utilization", ret); err != nil {
+		return types.GPUSnapshot{}, err
+	}
+
+	mem, ret := d.handle.GetMemoryInfo()
+	if err := d.wrapErr("memory info", ret); err != nil {
+		return types.GPUSnapshot{}, err
+	}
+
+	temp, ret := d.handle.GetTemperature(gonvml.TEMPERATURE_GPU)
+	if err := d.wrapErr("temperature", ret); err != nil {
+		return types.GPUSnapshot{}, err
+	}
+
+	// NVML power reporting 단위는 milliwatts이므로 1000으로 나눠 Watts로 변환한다.
+	powerMilliWatts, ret := d.handle.GetPowerUsage()
+	if err := d.wrapErr("power usage", ret); err != nil {
+		return types.GPUSnapshot{}, err
+	}
+
+	return types.GPUSnapshot{
+		Device:           info,
+		UtilizationPct:   uint(util.Gpu),
+		MemoryUsedBytes:  mem.Used,
+		MemoryTotalBytes: mem.Total,
+		TemperatureC:     uint(temp),
+		PowerUsageWatts:  float64(powerMilliWatts) / 1000.0,
+	}, nil
+}
+
+func (d *deviceImpl) RunningProcesses() ([]types.GPUProcess, error) {
+	procs, ret := d.handle.GetComputeRunningProcesses()
+	if err := d.wrapErr("running processes", ret); err != nil {
+		return nil, err
+	}
+	result := make([]types.GPUProcess, 0, len(procs))
+	for _, p := range procs {
+		result = append(result, types.GPUProcess{
+			DeviceIndex:     d.index,
+			PID:             p.Pid,
+			MemoryUsedBytes: p.UsedGpuMemory,
+		})
+	}
+	return result, nil
 }

--- a/internal/gpuobs/nvml/nvml.go
+++ b/internal/gpuobs/nvml/nvml.go
@@ -26,8 +26,9 @@ type Device interface {
 }
 
 // Init은 NVML 라이브러리(libnvidia-ml.so.1)를 런타임에 dlopen하고 초기화한다.
-// 실패 시 에러를 반환하므로 호출자(collector)가 warn 로그 후 graceful disable을
-// 선택할 수 있으며, non-GPU 노드에서도 바이너리가 기동을 멈추지 않는다.
+// 실패 시 에러를 반환하며, 상위 초기화 경로(현재 `cmd/gpuobs-agent/main.go`)가 이를 기록한 뒤
+// collector에 nil 핸들을 주입해 graceful disable을 구성한다.
+// 그 결과 non-GPU 노드에서도 바이너리가 기동을 멈추지 않는다.
 func Init() (NVML, error) {
 	if err := nvmlErr("nvml init", gonvml.Init()); err != nil {
 		return nil, err

--- a/internal/gpuobs/nvml/nvml.go
+++ b/internal/gpuobs/nvml/nvml.go
@@ -58,7 +58,22 @@ func (n *nvmlImpl) Device(index uint) (Device, error) {
 	if err := nvmlErr(fmt.Sprintf("device handle idx=%d", index), ret); err != nil {
 		return nil, err
 	}
-	return &deviceImpl{handle: handle, index: index}, nil
+
+	d := &deviceImpl{handle: handle, index: index}
+
+	// UUID와 모델명은 device 수명 동안 불변이므로 최초 1회 조회해 `info`에 캐싱한다.
+	// 이후 Snapshot은 NVML 재조회 없이 캐시된 값을 그대로 재사용한다.
+	uuid, ret := handle.GetUUID()
+	if err := d.wrapErr("device uuid", ret); err != nil {
+		return nil, err
+	}
+	name, ret := handle.GetName()
+	if err := d.wrapErr("device name", ret); err != nil {
+		return nil, err
+	}
+	d.info = types.GPUDevice{Index: index, UUID: uuid, Model: name}
+
+	return d, nil
 }
 
 func (n *nvmlImpl) Shutdown() error {
@@ -68,6 +83,7 @@ func (n *nvmlImpl) Shutdown() error {
 type deviceImpl struct {
 	handle gonvml.Device
 	index  uint
+	info   types.GPUDevice
 }
 
 // wrapErr는 device 호출 에러에 device index 컨텍스트를 덧붙여 래핑한다.
@@ -78,28 +94,14 @@ func (d *deviceImpl) wrapErr(op string, ret gonvml.Return) error {
 	return fmt.Errorf("%s idx=%d: %s", op, d.index, gonvml.ErrorString(ret))
 }
 
+// Info는 Device 생성 시 캐싱된 정적 정보를 그대로 반환한다.
+// 현재 구현에서는 에러를 돌려줄 경로가 없지만, 다른 백엔드에서의 재조회 패턴을 허용하기 위해
+// 인터페이스 시그니처는 그대로 유지한다.
 func (d *deviceImpl) Info() (types.GPUDevice, error) {
-	uuid, ret := d.handle.GetUUID()
-	if err := d.wrapErr("device uuid", ret); err != nil {
-		return types.GPUDevice{}, err
-	}
-	name, ret := d.handle.GetName()
-	if err := d.wrapErr("device name", ret); err != nil {
-		return types.GPUDevice{}, err
-	}
-	return types.GPUDevice{
-		Index: d.index,
-		UUID:  uuid,
-		Model: name,
-	}, nil
+	return d.info, nil
 }
 
 func (d *deviceImpl) Snapshot() (types.GPUSnapshot, error) {
-	info, err := d.Info()
-	if err != nil {
-		return types.GPUSnapshot{}, err
-	}
-
 	util, ret := d.handle.GetUtilizationRates()
 	if err := d.wrapErr("utilization", ret); err != nil {
 		return types.GPUSnapshot{}, err
@@ -122,7 +124,7 @@ func (d *deviceImpl) Snapshot() (types.GPUSnapshot, error) {
 	}
 
 	return types.GPUSnapshot{
-		Device:           info,
+		Device:           d.info,
 		UtilizationPct:   uint(util.Gpu),
 		MemoryUsedBytes:  mem.Used,
 		MemoryTotalBytes: mem.Total,


### PR DESCRIPTION
## Summary

- go-nvml(`v0.13.0-1`, purego) 기반 dlopen 구현을 `internal/gpuobs/nvml`에 추가하고, collector를 `GPU_POLL_INTERVAL` 주기로 device 스냅샷을 수집·발행하는 폴링 루프로 재작성했다
- device 단위 Gauge 5종(`gpuobs_device_*`)을 `{node, gpu_uuid, gpu_index, gpu_model}` 라벨로 Prometheus에 노출한다
- NVML 초기화 실패 또는 `GPU_METRICS_ENABLED=false` 조건에서는 graceful disable 경로로 분기해 non-GPU 노드에서도 바이너리 기동과 `/healthz`·`/readyz=200` 응답이 유지된다

## 주요 설계 결정

1. **NVML Shutdown 주체**: `collector.Run` 내부 defer에서 정상 경로에 한해 호출한다. main은 `nvml.Init` 실패 시 nil 핸들을 주입해 collector가 graceful disable로 분기하므로 Shutdown 책임은 collector가 소유한다
2. **node 라벨 주입 경로**: netobs의 metadata informer 경로가 없어 `cfg.NodeName`을 collector가 캡처해 `metrics.Record(node, snapshot)` 인자로 전달한다
3. **빌드 체인 per-agent CGO 토글**: go-nvml v0.13.x는 NVML 호출을 CGO import "C" 경로로 구현해 CGO_ENABLED=0 빌드에서는 심볼이 해석되지 않는다. Dockerfile에 ARG CGO_ENABLED=0 기본값을 두고 Makefile에 CGO_<agent> 매핑을 도입해, netobs는 기존 정적 바이너리 속성을 유지하고 gpuobs만 CGO_ENABLED=1로 빌드한다. Phase 1 설계 문서의 "purego 경로" 가정은 이 버전에서 성립하지 않아 철회된다.
4. **`/readyz` 정책**: NVML 실패·비활성화 시에도 `/readyz=200`을 유지해 DaemonSet rollout 파급을 차단한다. 수용 조건의 `/healthz=200` 과 양립하며 Prometheus endpoint discovery도 끊기지 않는다
5. **빌드 체인 per-agent CGO 토글**: go-nvml v0.13.x가 NVML 호출을 CGO `import "C"` 경로로 구현하고 있어 gpuobs 이미지는 `CGO_ENABLED=1`이 필요하다. Dockerfile에 `ARG CGO_ENABLED=0` 기본값을 두고 Makefile에 `CGO_<agent>` 매핑을 도입해, netobs는 기존 정적 바이너리 속성을 유지하고 gpuobs만 동적 링크로 빌드한다.

## 운영 영향

- **카디널리티**: `gpuobs_device_*` 라벨은 노드당 device 수(통상 ≤8)로 제한되어 netobs의 pod 단위 메트릭과 달리 별도 escape hatch 없이 안전하다
- **DCGM Exporter 공존**: gpuobs는 `gpuobs_*` prefix, 포트 9820, 별도 ClusterRole·ServiceMonitor로 동작하여 DCGM(`DCGM_*`, 9400)과 충돌 지점 없이 공존한다
- **non-GPU 노드**: `NVIDIA_VISIBLE_DEVICES=all` + `NVIDIA_DRIVER_CAPABILITIES=utility`로 nvidia-container-toolkit이 libnvidia-ml.so.1을 주입하는 노드에서만 폴링이 돌고, 주입이 없는 일반 워커에서는 warn 로그 후 device polling을 스킵한다
- **바이너리 링크 방식**: gpuobs 이미지는 CGO 기반이라 runtime stage(`debian:bookworm-slim`)의 glibc를 동적 링크한다. netobs는 기존 정적 바이너리 그대로다

## 수용 조건 대조

| 수용 조건 | 결과 |
|---|---|
| GPU 카나리 노드 `/metrics`에 5개 device 지표 노출 | ✅ RTX 3090 실측 |
| non-GPU 노드 기동 시 warn 로그 + `/healthz=200` 유지 | ✅ graceful disable 경로 |
| NVML 없이 CI 단위 테스트 통과 | ✅ `go test ./internal/gpuobs/... -race -count=3` |
| 폴링 주기 config 조정 가능 | ✅ `GPU_POLL_INTERVAL` env / `-poll-interval` flag |

## 로컬 실측 `/metrics` 스냅샷
```
gpuobs_agent_info{version="dev"} 1
gpuobs_device_memory_total_bytes{gpu_index="0",gpu_model="NVIDIA GeForce RTX 3090",gpu_uuid="GPU-f9252e5f-...",node="gpu"} 2.5769803776e+10
gpuobs_device_memory_used_bytes{...} 4.43285504e+08
gpuobs_device_power_usage_watts{...} 29.23
gpuobs_device_temperature_celsius{...} 26
gpuobs_device_utilization_percent{...} 0
```

## 커밋 구성

| SHA | 요약 |
|---|---|
| `db0231b` | go-nvml 의존성 + dlopen 기반 NVML 구현 (`internal/gpuobs/nvml/nvml.go`), placeholder doc.go 정리 |
| `d300374` | `GPU_POLL_INTERVAL`·`GPU_METRICS_ENABLED` config 확장 |
| `9acd41f` | device 5종 Prometheus Gauge 등록 및 `Record(node, snap)` 구현 |
| `be8f4fb` | ticker 기반 NVML 폴링 루프 및 main DI 연결 |
| `64d2c0d` | fake NVML 기반 collector 단위 테스트 4경로 |
| `7937bec` | README Configuration·Metrics 표 확장 |

## Test plan

- [x] `go test ./internal/gpuobs/... -race -count=3` 통과
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build` 정적 바이너리 생성 확인
- [x] 로컬 GPU 노드에서 `/metrics` 5종 device 지표 실측 노출
- [x] `GPU_METRICS_ENABLED=false` 경로 smoke: device 지표 미노출, `/readyz=200` 유지
- [x] `-h` / `-help` exit 0 확인
- [x] `make build-netobs-agent` → 정적 바이너리, `make build-gpuobs-agent` → CGO 동적 링크 확인
- [ ] 카나리 노드 배포 후 Prometheus ServiceMonitor scrape 확인

Closes #10
Refs #7