### PR TITLE
refactor(kube): netobs/gpuobs 공용 식별·Resolver를 internal/kube로 승격

### DIFF
--- a/cmd/netobs-agent/main.go
+++ b/cmd/netobs-agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"netobs/internal/kube"
 	"netobs/internal/netobs/config"
 	"netobs/internal/netobs/drop"
 	ebpfx "netobs/internal/netobs/ebpf"
@@ -35,10 +36,11 @@ func main() {
 	metrics.SetPodMetricsEnabled(cfg.PodMetricsEnabled)
 
 	var ebpfReady atomic.Bool
-	resolver := metadata.NewResolver(cfg.NodeName, cfg.MetadataRefresh)
+	kr := kube.NewResolver(cfg.NodeName, cfg.MetadataRefresh)
+	enricher := metadata.NewEnricher(kr)
 
 	ready := func() (bool, string) {
-		if !resolver.HasSynced() {
+		if !kr.HasSynced() {
 			return false, "metadata informer not synced"
 		}
 		if !ebpfReady.Load() {
@@ -63,7 +65,7 @@ func main() {
 	}()
 
 	// Kubernetes metadata informer.
-	go resolver.Start(ctx)
+	go kr.Start(ctx)
 
 	mapper := drop.NewMapper(drop.DefaultPaths(cfg.DropReasonFormatPath))
 
@@ -92,7 +94,7 @@ func main() {
 				continue
 			}
 
-			enriched := resolver.Enrich(ev, mapper)
+			enriched := enricher.Enrich(ev, mapper)
 			metrics.Record(enriched)
 
 			if cfg.PrintEvents {

--- a/cmd/netobs-agent/main.go
+++ b/cmd/netobs-agent/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	ready := func() (bool, string) {
 		if !kr.HasSynced() {
-			return false, "metadata informer not synced"
+			return false, "kube resolver informer not synced"
 		}
 		if !ebpfReady.Load() {
 			return false, "ebpf not attached"

--- a/internal/kube/identity.go
+++ b/internal/kube/identity.go
@@ -122,14 +122,16 @@ func (p PodIdentity) WorkloadLabel() string {
 	}
 }
 
-// normalizeWorkloadName은 ReplicaSet 등 generated suffix가 붙은 owner 이름을 부모 워크로드 이름으로 정규화한다.
-// StatefulSet은 안정 이름이라 그대로 둔다.
+// normalizeWorkloadName은 ReplicaSet의 generated hash suffix를 제거해 부모 Deployment 이름을 복원한다.
+// hashlike 휴리스틱은 길이만 보고 영숫자 suffix를 자르므로 ReplicaSet 외 워크로드(예: DaemonSet "node-exporter",
+// 안정 이름 Job 등)에 적용하면 false-positive로 의미 있는 이름까지 잘려나간다. 이를 방지하기 위해
+// ReplicaSet에만 trim을 시도하고 그 외에는 입력 이름을 그대로 보존한다.
 func normalizeWorkloadName(kind, name string) string {
 	if name == "" {
 		return ""
 	}
 
-	if kind == "StatefulSet" {
+	if kind != "ReplicaSet" {
 		return name
 	}
 

--- a/internal/kube/identity.go
+++ b/internal/kube/identity.go
@@ -1,0 +1,270 @@
+// Package kube는 netobs/gpuobs가 공통으로 사용하는 Kubernetes 식별/해석 유틸을 제공한다.
+// PodIdentity 등 식별 모델과 informer 기반 IP→identity Resolver를 한 곳으로 모아,
+// netobs(Event 기반 enrich)와 gpuobs(PID 기반 Pod 귀속)가 동일한 식별 어휘를 공유하도록 한다.
+package kube
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IdentityClass는 PodIdentity가 가리키는 대상의 종류를 분류한다.
+// Pod/Service/Node가 식별된 경우와 외부/미해결을 구분해 메트릭 라벨과 traffic scope 판정에 쓰인다.
+const (
+	IdentityClassPod        = "pod"
+	IdentityClassNode       = "node"
+	IdentityClassService    = "service"
+	IdentityClassExternal   = "external"
+	IdentityClassUnresolved = "unresolved"
+)
+
+// PodIdentity는 Pod/Service/Node/External/Unresolved 어느 한 쪽으로 분류된 통신 상대를 표현한다.
+// 필드는 IdentityClass에 따라 부분적으로 채워지며, NamespaceLabel/WorkloadLabel/WorkloadKey 등은
+// 비어 있는 필드를 안전한 기본 라벨("unknown" 등)로 대체해 Prometheus 라벨 카디널리티를 통제한다.
+type PodIdentity struct {
+	IdentityClass string
+	Namespace     string
+	PodUID        string
+	PodName       string
+	NodeName      string
+	WorkloadKind  string
+	Workload      string
+	PodIP         string
+}
+
+// Known은 PodIdentity가 미해결 상태가 아닌지 반환한다.
+func (p PodIdentity) Known() bool {
+	return !p.IsUnresolved()
+}
+
+func (p PodIdentity) IsPod() bool {
+	return p.IdentityClass == IdentityClassPod
+}
+
+func (p PodIdentity) IsNode() bool {
+	return p.IdentityClass == IdentityClassNode
+}
+
+func (p PodIdentity) IsService() bool {
+	return p.IdentityClass == IdentityClassService
+}
+
+func (p PodIdentity) IsExternal() bool {
+	return p.IdentityClass == IdentityClassExternal
+}
+
+func (p PodIdentity) IsUnresolved() bool {
+	return p.IdentityClass == IdentityClassUnresolved || p.IdentityClass == ""
+}
+
+// NamespaceLabel은 Prometheus 라벨에 쓸 namespace 표현을 반환한다.
+// Pod/Service에는 실제 namespace, Node에는 "host", External/Unresolved에는 분류명 자체를 사용한다.
+func (p PodIdentity) NamespaceLabel() string {
+	switch p.IdentityClass {
+	case IdentityClassPod:
+		if p.Namespace == "" {
+			return "unknown"
+		}
+		return p.Namespace
+	case IdentityClassNode:
+		return "host"
+	case IdentityClassService:
+		if p.Namespace == "" {
+			return "service"
+		}
+		return p.Namespace
+	case IdentityClassExternal:
+		return "external"
+	case IdentityClassUnresolved:
+		return "unresolved"
+	default:
+		return "unknown"
+	}
+}
+
+// WorkloadLabel은 Prometheus 라벨에 쓸 워크로드 표현을 반환한다.
+// Deployment/StatefulSet/DaemonSet 등 owner가 있으면 정규화된 owner 이름을, 없으면 Pod 이름을 사용해
+// "unknown" 남발을 줄인다.
+func (p PodIdentity) WorkloadLabel() string {
+	switch p.IdentityClass {
+	case IdentityClassPod:
+		if p.Workload != "" {
+			name := normalizeWorkloadName(p.WorkloadKind, p.Workload)
+			if name != "" {
+				return name
+			}
+		}
+		if p.PodName != "" {
+			return p.PodName
+		}
+		return "unknown"
+
+	case IdentityClassNode:
+		if p.NodeName != "" {
+			return "node/" + p.NodeName
+		}
+		return "host-network"
+
+	case IdentityClassService:
+		if p.Workload != "" {
+			return "svc/" + p.Workload
+		}
+		return "service"
+
+	case IdentityClassExternal:
+		return "external"
+
+	case IdentityClassUnresolved:
+		return "unresolved"
+
+	default:
+		return "unknown"
+	}
+}
+
+// normalizeWorkloadName은 ReplicaSet 등 generated suffix가 붙은 owner 이름을 부모 워크로드 이름으로 정규화한다.
+// StatefulSet은 안정 이름이라 그대로 둔다.
+func normalizeWorkloadName(kind, name string) string {
+	if name == "" {
+		return ""
+	}
+
+	if kind == "StatefulSet" {
+		return name
+	}
+
+	if trimmed := TrimGeneratedSuffix(name); trimmed != "" {
+		return trimmed
+	}
+	return name
+}
+
+// TrimGeneratedSuffix는 ReplicaSet/Deployment 자동 생성 hash suffix(예: -7d4f9b8c5)를 제거한 부모 이름을 반환한다.
+// suffix 형태가 hash-like가 아니면 빈 문자열을 돌려준다.
+func TrimGeneratedSuffix(name string) string {
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	last := parts[len(parts)-1]
+	if !isHashLikeSuffix(last) {
+		return ""
+	}
+
+	return strings.Join(parts[:len(parts)-1], "-")
+}
+
+func isHashLikeSuffix(s string) bool {
+	if len(s) < 8 || len(s) > 16 {
+		return false
+	}
+
+	for _, ch := range s {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// NodeLabel은 Prometheus 라벨에 쓸 노드 표현을 반환한다.
+func (p PodIdentity) NodeLabel() string {
+	if p.NodeName == "" {
+		return "unknown"
+	}
+	return p.NodeName
+}
+
+// String은 사람이 읽을 수 있는 식별 문자열을 반환한다.
+// namespace/pod, node/노드명, svc/서비스명 등 IdentityClass에 따라 형식을 달리하며,
+// 정보가 부족하면 PodIP fallback 후 분류명으로 폴백한다.
+func (p PodIdentity) String() string {
+	switch p.IdentityClass {
+	case IdentityClassPod:
+		if p.Namespace != "" && p.PodName != "" {
+			return fmt.Sprintf("%s/%s", p.Namespace, p.PodName)
+		}
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "pod"
+	case IdentityClassNode:
+		if p.NodeName != "" {
+			return "node/" + p.NodeName
+		}
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "host"
+	case IdentityClassService:
+		if p.Namespace != "" && p.Workload != "" {
+			return fmt.Sprintf("%s/svc/%s", p.Namespace, p.Workload)
+		}
+		if p.Workload != "" {
+			return "svc/" + p.Workload
+		}
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "service"
+	case IdentityClassExternal:
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "external"
+	case IdentityClassUnresolved:
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "unresolved"
+	default:
+		if p.PodIP != "" {
+			return p.PodIP
+		}
+		return "unknown"
+	}
+}
+
+// Rank는 두 식별이 충돌할 때 어느 쪽을 더 신뢰할지 결정하는 우선순위를 반환한다.
+// Pod > Service > Node > External > Unresolved 순으로 강한 식별이다.
+func (p PodIdentity) Rank() int {
+	switch p.IdentityClass {
+	case IdentityClassPod:
+		return 5
+	case IdentityClassService:
+		return 4
+	case IdentityClassNode:
+		return 3
+	case IdentityClassExternal:
+		return 2
+	case IdentityClassUnresolved:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// WorkloadKey는 namespace/kind/workload 3단으로 안정적인 워크로드 키를 만들어
+// 메트릭 라벨 그룹화와 식별 dedup의 키로 쓸 수 있게 한다.
+func (p PodIdentity) WorkloadKey() string {
+	switch p.IdentityClass {
+	case IdentityClassPod:
+		kind := p.WorkloadKind
+		if kind == "" {
+			kind = "Pod"
+		}
+		return p.NamespaceLabel() + "/" + kind + "/" + p.WorkloadLabel()
+	case IdentityClassService:
+		return p.NamespaceLabel() + "/Service/" + p.WorkloadLabel()
+	case IdentityClassNode:
+		return "host/Node/" + p.WorkloadLabel()
+	case IdentityClassExternal:
+		return "external/External/external"
+	case IdentityClassUnresolved:
+		return "unresolved/Unresolved/unresolved"
+	default:
+		return "unknown/Unknown/unknown"
+	}
+}

--- a/internal/kube/identity_test.go
+++ b/internal/kube/identity_test.go
@@ -1,0 +1,261 @@
+package kube
+
+import "testing"
+
+func TestPodIdentity_ClassPredicates(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      PodIdentity
+		isPod   bool
+		isSvc   bool
+		isNode  bool
+		isExt   bool
+		isUnres bool
+		isKnown bool
+	}{
+		{"pod", PodIdentity{IdentityClass: IdentityClassPod}, true, false, false, false, false, true},
+		{"service", PodIdentity{IdentityClass: IdentityClassService}, false, true, false, false, false, true},
+		{"node", PodIdentity{IdentityClass: IdentityClassNode}, false, false, true, false, false, true},
+		{"external", PodIdentity{IdentityClass: IdentityClassExternal}, false, false, false, true, false, true},
+		{"unresolved-explicit", PodIdentity{IdentityClass: IdentityClassUnresolved}, false, false, false, false, true, false},
+		{"unresolved-zero", PodIdentity{}, false, false, false, false, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.IsPod(); got != tc.isPod {
+				t.Errorf("IsPod=%v want %v", got, tc.isPod)
+			}
+			if got := tc.id.IsService(); got != tc.isSvc {
+				t.Errorf("IsService=%v want %v", got, tc.isSvc)
+			}
+			if got := tc.id.IsNode(); got != tc.isNode {
+				t.Errorf("IsNode=%v want %v", got, tc.isNode)
+			}
+			if got := tc.id.IsExternal(); got != tc.isExt {
+				t.Errorf("IsExternal=%v want %v", got, tc.isExt)
+			}
+			if got := tc.id.IsUnresolved(); got != tc.isUnres {
+				t.Errorf("IsUnresolved=%v want %v", got, tc.isUnres)
+			}
+			if got := tc.id.Known(); got != tc.isKnown {
+				t.Errorf("Known=%v want %v", got, tc.isKnown)
+			}
+		})
+	}
+}
+
+func TestPodIdentity_NamespaceLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		id   PodIdentity
+		want string
+	}{
+		{"pod-with-ns", PodIdentity{IdentityClass: IdentityClassPod, Namespace: "kube-system"}, "kube-system"},
+		{"pod-without-ns", PodIdentity{IdentityClass: IdentityClassPod}, "unknown"},
+		{"node-always-host", PodIdentity{IdentityClass: IdentityClassNode}, "host"},
+		{"service-with-ns", PodIdentity{IdentityClass: IdentityClassService, Namespace: "default"}, "default"},
+		{"service-without-ns", PodIdentity{IdentityClass: IdentityClassService}, "service"},
+		{"external", PodIdentity{IdentityClass: IdentityClassExternal}, "external"},
+		{"unresolved", PodIdentity{IdentityClass: IdentityClassUnresolved}, "unresolved"},
+		{"zero", PodIdentity{}, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.NamespaceLabel(); got != tc.want {
+				t.Errorf("NamespaceLabel=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodIdentity_WorkloadLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		id   PodIdentity
+		want string
+	}{
+		{
+			name: "pod-deployment-trims-hash",
+			id:   PodIdentity{IdentityClass: IdentityClassPod, WorkloadKind: "ReplicaSet", Workload: "frontend-7d4f9b8c5", PodName: "frontend-7d4f9b8c5-xyz12"},
+			want: "frontend",
+		},
+		{
+			name: "pod-statefulset-keeps-name",
+			id:   PodIdentity{IdentityClass: IdentityClassPod, WorkloadKind: "StatefulSet", Workload: "redis-0"},
+			want: "redis-0",
+		},
+		{
+			name: "pod-no-workload-falls-back-to-podname",
+			id:   PodIdentity{IdentityClass: IdentityClassPod, PodName: "naked-pod"},
+			want: "naked-pod",
+		},
+		{
+			name: "pod-empty-everything",
+			id:   PodIdentity{IdentityClass: IdentityClassPod},
+			want: "unknown",
+		},
+		{
+			name: "node-with-name",
+			id:   PodIdentity{IdentityClass: IdentityClassNode, NodeName: "node-1"},
+			want: "node/node-1",
+		},
+		{
+			name: "node-without-name",
+			id:   PodIdentity{IdentityClass: IdentityClassNode},
+			want: "host-network",
+		},
+		{
+			name: "service-with-name",
+			id:   PodIdentity{IdentityClass: IdentityClassService, Workload: "kubernetes"},
+			want: "svc/kubernetes",
+		},
+		{
+			name: "external",
+			id:   PodIdentity{IdentityClass: IdentityClassExternal},
+			want: "external",
+		},
+		{
+			name: "unresolved",
+			id:   PodIdentity{IdentityClass: IdentityClassUnresolved},
+			want: "unresolved",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.WorkloadLabel(); got != tc.want {
+				t.Errorf("WorkloadLabel=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodIdentity_Rank(t *testing.T) {
+	// Rank가 단순한 상수 매핑이라 정확한 값보다는 우선순위 관계가 깨지지 않는지를 본다.
+	pod := PodIdentity{IdentityClass: IdentityClassPod}
+	svc := PodIdentity{IdentityClass: IdentityClassService}
+	node := PodIdentity{IdentityClass: IdentityClassNode}
+	ext := PodIdentity{IdentityClass: IdentityClassExternal}
+	un := PodIdentity{IdentityClass: IdentityClassUnresolved}
+
+	if !(pod.Rank() > svc.Rank() && svc.Rank() > node.Rank() && node.Rank() > ext.Rank() && ext.Rank() > un.Rank()) {
+		t.Fatalf("rank ordering broken: pod=%d svc=%d node=%d ext=%d un=%d",
+			pod.Rank(), svc.Rank(), node.Rank(), ext.Rank(), un.Rank())
+	}
+}
+
+func TestPodIdentity_String(t *testing.T) {
+	cases := []struct {
+		name string
+		id   PodIdentity
+		want string
+	}{
+		{"pod-ns-name", PodIdentity{IdentityClass: IdentityClassPod, Namespace: "default", PodName: "p1"}, "default/p1"},
+		{"pod-ip-fallback", PodIdentity{IdentityClass: IdentityClassPod, PodIP: "10.0.0.1"}, "10.0.0.1"},
+		{"pod-empty", PodIdentity{IdentityClass: IdentityClassPod}, "pod"},
+		{"node-name", PodIdentity{IdentityClass: IdentityClassNode, NodeName: "n1"}, "node/n1"},
+		{"service-ns-workload", PodIdentity{IdentityClass: IdentityClassService, Namespace: "default", Workload: "svc"}, "default/svc/svc"},
+		{"external-ip", PodIdentity{IdentityClass: IdentityClassExternal, PodIP: "1.1.1.1"}, "1.1.1.1"},
+		{"unresolved-empty", PodIdentity{IdentityClass: IdentityClassUnresolved}, "unresolved"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.String(); got != tc.want {
+				t.Errorf("String=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodIdentity_WorkloadKey(t *testing.T) {
+	cases := []struct {
+		name string
+		id   PodIdentity
+		want string
+	}{
+		{
+			name: "pod-with-deployment",
+			id:   PodIdentity{IdentityClass: IdentityClassPod, Namespace: "default", WorkloadKind: "Deployment", Workload: "api"},
+			want: "default/Deployment/api",
+		},
+		{
+			name: "pod-without-kind",
+			id:   PodIdentity{IdentityClass: IdentityClassPod, Namespace: "default", PodName: "naked"},
+			want: "default/Pod/naked",
+		},
+		{
+			name: "service",
+			id:   PodIdentity{IdentityClass: IdentityClassService, Namespace: "default", Workload: "kubernetes"},
+			want: "default/Service/svc/kubernetes",
+		},
+		{
+			name: "node",
+			id:   PodIdentity{IdentityClass: IdentityClassNode, NodeName: "n1"},
+			want: "host/Node/node/n1",
+		},
+		{
+			name: "external",
+			id:   PodIdentity{IdentityClass: IdentityClassExternal},
+			want: "external/External/external",
+		},
+		{
+			name: "unresolved",
+			id:   PodIdentity{IdentityClass: IdentityClassUnresolved},
+			want: "unresolved/Unresolved/unresolved",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.WorkloadKey(); got != tc.want {
+				t.Errorf("WorkloadKey=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrimGeneratedSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"deployment-with-rs-hash", "frontend-7d4f9b8c5", "frontend"},
+		{"two-level-name-with-hash", "frontend-api-7d4f9b8c5", "frontend-api"},
+		{"single-segment", "frontend", ""},
+		{"hash-too-short", "frontend-abc", ""},
+		{"hash-too-long-still-valid", "frontend-abcdef0123456", "frontend"},
+		{"hash-way-too-long", "frontend-abcdef01234567890", ""},
+		{"hash-uppercase-not-hashlike", "frontend-ABCDEF01", ""},
+		{"hash-with-symbol-not-hashlike", "frontend-abcdef0!", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TrimGeneratedSuffix(tc.in); got != tc.want {
+				t.Errorf("TrimGeneratedSuffix(%q)=%q want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeWorkloadName(t *testing.T) {
+	// hashlike 휴리스틱은 length 8~16의 lowercase 영숫자 suffix면 모두 trim하므로
+	// "node-exporter"처럼 8자 영문자 suffix가 붙은 이름은 의도와 무관하게 잘려나간다.
+	// 본 테스트는 그런 false-positive를 우회하는 짧은 suffix(5자) 이름으로 통과 동작을 검증한다.
+	cases := []struct {
+		name string
+		kind string
+		in   string
+		want string
+	}{
+		{"replicaset-trimmed", "ReplicaSet", "frontend-7d4f9b8c5", "frontend"},
+		{"statefulset-untouched", "StatefulSet", "redis-0", "redis-0"},
+		{"daemonset-short-suffix-passthrough", "DaemonSet", "kube-proxy", "kube-proxy"},
+		{"empty-name", "ReplicaSet", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeWorkloadName(tc.kind, tc.in); got != tc.want {
+				t.Errorf("normalizeWorkloadName(%q, %q)=%q want %q", tc.kind, tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/kube/identity_test.go
+++ b/internal/kube/identity_test.go
@@ -237,9 +237,8 @@ func TestTrimGeneratedSuffix(t *testing.T) {
 }
 
 func TestNormalizeWorkloadName(t *testing.T) {
-	// hashlike 휴리스틱은 length 8~16의 lowercase 영숫자 suffix면 모두 trim하므로
-	// "node-exporter"처럼 8자 영문자 suffix가 붙은 이름은 의도와 무관하게 잘려나간다.
-	// 본 테스트는 그런 false-positive를 우회하는 짧은 suffix(5자) 이름으로 통과 동작을 검증한다.
+	// trim은 ReplicaSet에 한해 적용되며, DaemonSet/Job/StatefulSet 등 다른 kind는
+	// hashlike suffix가 붙어 있어도 보존되어야 한다. (false-positive 방지)
 	cases := []struct {
 		name string
 		kind string
@@ -247,9 +246,12 @@ func TestNormalizeWorkloadName(t *testing.T) {
 		want string
 	}{
 		{"replicaset-trimmed", "ReplicaSet", "frontend-7d4f9b8c5", "frontend"},
+		{"replicaset-empty-name", "ReplicaSet", "", ""},
+		{"replicaset-no-hash-passthrough", "ReplicaSet", "frontend", "frontend"},
 		{"statefulset-untouched", "StatefulSet", "redis-0", "redis-0"},
-		{"daemonset-short-suffix-passthrough", "DaemonSet", "kube-proxy", "kube-proxy"},
-		{"empty-name", "ReplicaSet", "", ""},
+		{"daemonset-hashlike-suffix-preserved", "DaemonSet", "node-exporter", "node-exporter"},
+		{"job-hashlike-suffix-preserved", "Job", "backup-snapshot", "backup-snapshot"},
+		{"deployment-direct-untouched", "Deployment", "api-server", "api-server"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/kube/resolver.go
+++ b/internal/kube/resolver.go
@@ -1,0 +1,659 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Resolver는 클러스터의 Pod/Service/Node IP 인덱스를 informer로 유지하고
+// IP → PodIdentity 해석을 제공한다. netobs(Event 기반 enrich)와 gpuobs(PID 기반 Pod 귀속)
+// 양쪽 모두가 동일한 인덱스를 공유할 수 있도록 공용 패키지에 둔다.
+type Resolver struct {
+	localNode    string
+	client       kubernetes.Interface
+	startupErr   error
+	resyncPeriod time.Duration
+
+	synced atomic.Bool
+
+	mu sync.RWMutex
+
+	podByIP     map[string]podCacheEntry
+	podIPsByKey map[string][]string
+
+	serviceByIP     map[string]serviceCacheEntry
+	serviceIPsByKey map[string][]string
+
+	nodeByIP     map[string]string
+	nodeIPsByKey map[string][]string
+}
+
+type podCacheEntry struct {
+	key string
+	id  PodIdentity
+}
+
+type serviceCacheEntry struct {
+	key string
+	id  PodIdentity
+}
+
+// NewResolver는 in-cluster 또는 kubeconfig에서 client를 구성한 Resolver를 반환한다.
+// client 초기화에 실패해도 Resolver 자체는 비활성 상태로 반환되며, Start 시 disabled 로그를 남긴다.
+// 이 graceful 동작은 클러스터 외부 개발 환경에서 바이너리가 멈추지 않게 한다.
+func NewResolver(localNode string, resyncPeriod time.Duration) *Resolver {
+	r := &Resolver{
+		localNode:       localNode,
+		resyncPeriod:    resyncPeriod,
+		podByIP:         make(map[string]podCacheEntry),
+		podIPsByKey:     make(map[string][]string),
+		serviceByIP:     make(map[string]serviceCacheEntry),
+		serviceIPsByKey: make(map[string][]string),
+		nodeByIP:        make(map[string]string),
+		nodeIPsByKey:    make(map[string][]string),
+	}
+
+	cfg, err := kubeConfig()
+	if err != nil {
+		r.startupErr = err
+		return r
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		r.startupErr = err
+		return r
+	}
+
+	r.client = clientset
+	return r
+}
+
+// LocalNode는 NewResolver에 전달된 관측 노드 이름을 반환한다.
+// netobs Enricher가 ObservedNode 필드 기록에 사용한다.
+func (r *Resolver) LocalNode() string {
+	return r.localNode
+}
+
+func kubeConfig() (*rest.Config, error) {
+	if cfg, err := rest.InClusterConfig(); err == nil {
+		return cfg, nil
+	}
+
+	if kubeconfig := strings.TrimSpace(os.Getenv("KUBECONFIG")); kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		path := filepath.Join(home, ".kube", "config")
+		if _, statErr := os.Stat(path); statErr == nil {
+			return clientcmd.BuildConfigFromFlags("", path)
+		}
+	}
+
+	return nil, errors.New("no in-cluster config and no kubeconfig found")
+}
+
+// Start는 Pod/Service/Node informer를 띄우고 초기 sync가 완료될 때까지 대기한 뒤 ctx 종료까지 블록된다.
+// client 미구성 시 disabled 로그만 남기고 즉시 반환해 호출자가 별도 분기 없이 goroutine으로 실행해도 된다.
+func (r *Resolver) Start(ctx context.Context) {
+	if r.client == nil {
+		log.Printf("kube resolver disabled: %v", r.startupErr)
+		return
+	}
+
+	factory := informers.NewSharedInformerFactory(r.client, r.resyncPeriod)
+
+	podInformer := factory.Core().V1().Pods().Informer()
+	serviceInformer := factory.Core().V1().Services().Informer()
+	nodeInformer := factory.Core().V1().Nodes().Informer()
+
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.onUpsertPod(obj)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			r.onUpsertPod(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			r.onDeletePod(obj)
+		},
+	})
+
+	serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.onUpsertService(obj)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			r.onUpsertService(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			r.onDeleteService(obj)
+		},
+	})
+
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.onUpsertNode(obj)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			r.onUpsertNode(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			r.onDeleteNode(obj)
+		},
+	})
+
+	factory.Start(ctx.Done())
+
+	if !cache.WaitForCacheSync(
+		ctx.Done(),
+		podInformer.HasSynced,
+		serviceInformer.HasSynced,
+		nodeInformer.HasSynced,
+	) {
+		log.Printf("kube resolver initial sync failed")
+		return
+	}
+
+	r.synced.Store(true)
+	log.Printf("kube resolver informer sync completed")
+
+	<-ctx.Done()
+}
+
+// HasSynced는 informer 캐시가 초기 sync를 완료했는지 반환한다.
+// client 미구성으로 비활성 상태일 때도 false를 반환해 /readyz가 그 상태를 드러낼 수 있게 한다.
+func (r *Resolver) HasSynced() bool {
+	return r.synced.Load()
+}
+
+func (r *Resolver) onUpsertPod(obj interface{}) {
+	pod, ok := extractPod(obj)
+	if !ok || pod == nil {
+		return
+	}
+
+	key := podKey(pod)
+	ips := podIPs(*pod)
+	id := podIdentity(*pod)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.podIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if entry, ok := r.podByIP[ip]; ok && entry.key == key {
+				delete(r.podByIP, ip)
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		delete(r.podIPsByKey, key)
+		return
+	}
+
+	for _, ip := range ips {
+		r.podByIP[ip] = podCacheEntry{
+			key: key,
+			id:  id,
+		}
+	}
+	r.podIPsByKey[key] = ips
+}
+
+func (r *Resolver) onDeletePod(obj interface{}) {
+	pod, ok := extractPod(obj)
+	if !ok || pod == nil {
+		return
+	}
+
+	key := podKey(pod)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.podIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if entry, ok := r.podByIP[ip]; ok && entry.key == key {
+				delete(r.podByIP, ip)
+			}
+		}
+		delete(r.podIPsByKey, key)
+		return
+	}
+
+	// fallback: tombstone만 있고 key 캐시가 없는 경우
+	for _, ip := range podIPs(*pod) {
+		if entry, ok := r.podByIP[ip]; ok && entry.key == key {
+			delete(r.podByIP, ip)
+		}
+	}
+}
+
+func (r *Resolver) onUpsertService(obj interface{}) {
+	svc, ok := extractService(obj)
+	if !ok || svc == nil {
+		return
+	}
+
+	key := serviceKey(svc)
+	ips := serviceIPs(*svc)
+	id := serviceIdentity(*svc)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.serviceIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
+				delete(r.serviceByIP, ip)
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		delete(r.serviceIPsByKey, key)
+		return
+	}
+
+	for _, ip := range ips {
+		r.serviceByIP[ip] = serviceCacheEntry{
+			key: key,
+			id:  id,
+		}
+	}
+	r.serviceIPsByKey[key] = ips
+}
+
+func (r *Resolver) onDeleteService(obj interface{}) {
+	svc, ok := extractService(obj)
+	if !ok || svc == nil {
+		return
+	}
+
+	key := serviceKey(svc)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.serviceIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
+				delete(r.serviceByIP, ip)
+			}
+		}
+		delete(r.serviceIPsByKey, key)
+		return
+	}
+
+	for _, ip := range serviceIPs(*svc) {
+		if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
+			delete(r.serviceByIP, ip)
+		}
+	}
+}
+
+func (r *Resolver) onUpsertNode(obj interface{}) {
+	node, ok := extractNode(obj)
+	if !ok || node == nil {
+		return
+	}
+
+	key := nodeKey(node)
+	ips := nodeIPs(*node)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.nodeIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
+				delete(r.nodeByIP, ip)
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		delete(r.nodeIPsByKey, key)
+		return
+	}
+
+	for _, ip := range ips {
+		r.nodeByIP[ip] = node.Name
+	}
+	r.nodeIPsByKey[key] = ips
+}
+
+func (r *Resolver) onDeleteNode(obj interface{}) {
+	node, ok := extractNode(obj)
+	if !ok || node == nil {
+		return
+	}
+
+	key := nodeKey(node)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if oldIPs, exists := r.nodeIPsByKey[key]; exists {
+		for _, ip := range oldIPs {
+			if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
+				delete(r.nodeByIP, ip)
+			}
+		}
+		delete(r.nodeIPsByKey, key)
+		return
+	}
+
+	for _, ip := range nodeIPs(*node) {
+		if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
+			delete(r.nodeByIP, ip)
+		}
+	}
+}
+
+func extractPod(obj interface{}) (*corev1.Pod, bool) {
+	switch t := obj.(type) {
+	case *corev1.Pod:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		pod, ok := t.Obj.(*corev1.Pod)
+		return pod, ok
+	default:
+		return nil, false
+	}
+}
+
+func extractService(obj interface{}) (*corev1.Service, bool) {
+	switch t := obj.(type) {
+	case *corev1.Service:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		svc, ok := t.Obj.(*corev1.Service)
+		return svc, ok
+	default:
+		return nil, false
+	}
+}
+
+func extractNode(obj interface{}) (*corev1.Node, bool) {
+	switch t := obj.(type) {
+	case *corev1.Node:
+		return t, true
+	case cache.DeletedFinalStateUnknown:
+		node, ok := t.Obj.(*corev1.Node)
+		return node, ok
+	default:
+		return nil, false
+	}
+}
+
+func podKey(p *corev1.Pod) string {
+	if p.UID != "" {
+		return string(p.UID)
+	}
+	return p.Namespace + "/" + p.Name
+}
+
+func serviceKey(s *corev1.Service) string {
+	if s.UID != "" {
+		return string(s.UID)
+	}
+	return s.Namespace + "/" + s.Name
+}
+
+func nodeKey(n *corev1.Node) string {
+	if n.UID != "" {
+		return string(n.UID)
+	}
+	return n.Name
+}
+
+func podIPs(p corev1.Pod) []string {
+	seen := make(map[string]struct{}, 1+len(p.Status.PodIPs))
+	out := make([]string, 0, 1+len(p.Status.PodIPs))
+
+	if p.Status.PodIP != "" {
+		seen[p.Status.PodIP] = struct{}{}
+		out = append(out, p.Status.PodIP)
+	}
+
+	for _, pip := range p.Status.PodIPs {
+		if pip.IP == "" {
+			continue
+		}
+		if _, exists := seen[pip.IP]; exists {
+			continue
+		}
+		seen[pip.IP] = struct{}{}
+		out = append(out, pip.IP)
+	}
+
+	return out
+}
+
+func serviceIPs(s corev1.Service) []string {
+	seen := make(map[string]struct{}, 1+len(s.Spec.ClusterIPs))
+	out := make([]string, 0, 1+len(s.Spec.ClusterIPs))
+
+	if s.Spec.ClusterIP != "" && s.Spec.ClusterIP != "None" {
+		seen[s.Spec.ClusterIP] = struct{}{}
+		out = append(out, s.Spec.ClusterIP)
+	}
+
+	for _, ip := range s.Spec.ClusterIPs {
+		if ip == "" || ip == "None" {
+			continue
+		}
+		if _, exists := seen[ip]; exists {
+			continue
+		}
+		seen[ip] = struct{}{}
+		out = append(out, ip)
+	}
+
+	return out
+}
+
+func nodeIPs(n corev1.Node) []string {
+	seen := make(map[string]struct{}, len(n.Status.Addresses))
+	out := make([]string, 0, len(n.Status.Addresses))
+
+	for _, addr := range n.Status.Addresses {
+		if addr.Address == "" {
+			continue
+		}
+		if _, exists := seen[addr.Address]; exists {
+			continue
+		}
+		seen[addr.Address] = struct{}{}
+		out = append(out, addr.Address)
+	}
+
+	return out
+}
+
+func podIdentity(p corev1.Pod) PodIdentity {
+	kind, workload := ownerInfo(p)
+
+	return PodIdentity{
+		IdentityClass: IdentityClassPod,
+		Namespace:     p.Namespace,
+		PodUID:        string(p.UID),
+		PodName:       p.Name,
+		NodeName:      p.Spec.NodeName,
+		WorkloadKind:  kind,
+		Workload:      workload,
+		PodIP:         p.Status.PodIP,
+	}
+}
+
+func serviceIdentity(s corev1.Service) PodIdentity {
+	return PodIdentity{
+		IdentityClass: IdentityClassService,
+		Namespace:     s.Namespace,
+		WorkloadKind:  "Service",
+		Workload:      s.Name,
+		PodIP:         s.Spec.ClusterIP,
+	}
+}
+
+func nodeIdentity(nodeName, ip string) PodIdentity {
+	return PodIdentity{
+		IdentityClass: IdentityClassNode,
+		NodeName:      nodeName,
+		WorkloadKind:  "Node",
+		Workload:      nodeName,
+		PodIP:         ip,
+	}
+}
+
+func externalIdentity(ip string) PodIdentity {
+	return PodIdentity{
+		IdentityClass: IdentityClassExternal,
+		WorkloadKind:  "External",
+		Workload:      "external",
+		PodIP:         ip,
+	}
+}
+
+func unresolvedIdentity(ip string) PodIdentity {
+	return PodIdentity{
+		IdentityClass: IdentityClassUnresolved,
+		WorkloadKind:  "Unresolved",
+		Workload:      "unresolved",
+		PodIP:         ip,
+	}
+}
+
+func ownerInfo(p corev1.Pod) (string, string) {
+	if len(p.OwnerReferences) == 0 {
+		return "Pod", p.Name
+	}
+
+	owner := p.OwnerReferences[0]
+	kind := owner.Kind
+	name := owner.Name
+
+	if kind == "ReplicaSet" {
+		if dep := TrimGeneratedSuffix(name); dep != "" {
+			return "Deployment", dep
+		}
+	}
+
+	return kind, name
+}
+
+// identityCompleteness는 식별 필드가 얼마나 채워졌는지 점수화한다.
+// 같은 IdentityClass 내에서 StrongerIdentity의 tiebreak 용도로만 쓰인다.
+func identityCompleteness(p PodIdentity) int {
+	score := 0
+	if p.Namespace != "" {
+		score++
+	}
+	if p.PodUID != "" {
+		score++
+	}
+	if p.PodName != "" {
+		score++
+	}
+	if p.NodeName != "" {
+		score++
+	}
+	if p.Workload != "" {
+		score++
+	}
+	if p.WorkloadKind != "" {
+		score++
+	}
+	if p.PodIP != "" {
+		score++
+	}
+	return score
+}
+
+// StrongerIdentity는 두 PodIdentity 중 더 신뢰도가 높은 쪽을 반환한다.
+// Rank가 우선이며, 동률일 때는 채워진 필드 수가 많은 쪽을 택한다.
+// netobs Enricher가 IP 해석 결과와 flow/runtime hint를 병합할 때 사용한다.
+func StrongerIdentity(current, candidate PodIdentity) PodIdentity {
+	if candidate.Rank() > current.Rank() {
+		return candidate
+	}
+	if current.Rank() > candidate.Rank() {
+		return current
+	}
+
+	if identityCompleteness(candidate) > identityCompleteness(current) {
+		return candidate
+	}
+	return current
+}
+
+// WithObservedIP는 PodIdentity의 PodIP를 관측된 값으로 보강해 반환한다.
+// hint 캐시에 기록된 식별이 PodIP를 비워둘 수 있어, 호출 시점의 실제 IP로 채워준다.
+func WithObservedIP(id PodIdentity, ip string) PodIdentity {
+	if ip != "" {
+		id.PodIP = ip
+	}
+	return id
+}
+
+// ResolveIP는 IP 문자열을 PodIdentity로 해석한다.
+// 해석 우선순위는 Pod → Service → Node → 사설/특수 주소(unresolved) → public(external) 순이다.
+func (r *Resolver) ResolveIP(ip string) PodIdentity {
+	if ip == "" {
+		return unresolvedIdentity(ip)
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if entry, ok := r.podByIP[ip]; ok {
+		return entry.id
+	}
+	if entry, ok := r.serviceByIP[ip]; ok {
+		return entry.id
+	}
+	if nodeName, ok := r.nodeByIP[ip]; ok {
+		return nodeIdentity(nodeName, ip)
+	}
+	return classifyFallbackIP(ip)
+}
+
+// classifyFallbackIP는 인덱스에서 매칭이 없는 IP를 분류한다.
+// loopback/multicast/link-local/unspecified 및 RFC1918 등 사설 주소는 unresolved,
+// 그 외 public IP는 external로 분류한다.
+func classifyFallbackIP(ip string) PodIdentity {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return unresolvedIdentity(ip)
+	}
+
+	if addr.IsUnspecified() || addr.IsLoopback() || addr.IsMulticast() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return unresolvedIdentity(ip)
+	}
+
+	if addr.IsPrivate() {
+		return unresolvedIdentity(ip)
+	}
+
+	return externalIdentity(ip)
+}

--- a/internal/kube/resolver_test.go
+++ b/internal/kube/resolver_test.go
@@ -1,0 +1,154 @@
+package kube
+
+import "testing"
+
+// newSeededResolver는 informer 없이 IP 인덱스만 직접 채운 Resolver를 만든다.
+// 실제 informer 경로는 client-go에 위임된 영역이라 여기서는 ResolveIP의 분기와
+// classifyFallbackIP 동작만 격리해 검증한다.
+func newSeededResolver() *Resolver {
+	return &Resolver{
+		podByIP:         make(map[string]podCacheEntry),
+		podIPsByKey:     make(map[string][]string),
+		serviceByIP:     make(map[string]serviceCacheEntry),
+		serviceIPsByKey: make(map[string][]string),
+		nodeByIP:        make(map[string]string),
+		nodeIPsByKey:    make(map[string][]string),
+	}
+}
+
+func TestResolveIP_PodHit(t *testing.T) {
+	r := newSeededResolver()
+	want := PodIdentity{IdentityClass: IdentityClassPod, Namespace: "default", PodName: "p1", PodIP: "10.0.0.1"}
+	r.podByIP["10.0.0.1"] = podCacheEntry{key: "p1", id: want}
+
+	got := r.ResolveIP("10.0.0.1")
+	if got != want {
+		t.Fatalf("ResolveIP=%+v want %+v", got, want)
+	}
+}
+
+func TestResolveIP_ServiceHit(t *testing.T) {
+	r := newSeededResolver()
+	want := PodIdentity{IdentityClass: IdentityClassService, Namespace: "default", Workload: "kubernetes", PodIP: "10.96.0.1"}
+	r.serviceByIP["10.96.0.1"] = serviceCacheEntry{key: "kubernetes", id: want}
+
+	got := r.ResolveIP("10.96.0.1")
+	if got != want {
+		t.Fatalf("ResolveIP=%+v want %+v", got, want)
+	}
+}
+
+func TestResolveIP_NodeHit(t *testing.T) {
+	r := newSeededResolver()
+	r.nodeByIP["192.168.1.10"] = "node-a"
+
+	got := r.ResolveIP("192.168.1.10")
+	if !got.IsNode() {
+		t.Fatalf("expected node identity, got class=%q", got.IdentityClass)
+	}
+	if got.NodeName != "node-a" || got.PodIP != "192.168.1.10" {
+		t.Fatalf("ResolveIP=%+v want node-a/192.168.1.10", got)
+	}
+}
+
+func TestResolveIP_PodTakesPrecedenceOverService(t *testing.T) {
+	// 동일 IP에 pod와 service가 모두 등록되어 있으면 pod가 우선이어야 한다.
+	// IP 충돌은 비정상이지만 ResolveIP의 lookup 순서가 의도대로 유지되는지를 본다.
+	r := newSeededResolver()
+	r.podByIP["10.0.0.5"] = podCacheEntry{key: "p", id: PodIdentity{IdentityClass: IdentityClassPod, PodIP: "10.0.0.5"}}
+	r.serviceByIP["10.0.0.5"] = serviceCacheEntry{key: "svc", id: PodIdentity{IdentityClass: IdentityClassService, PodIP: "10.0.0.5"}}
+
+	got := r.ResolveIP("10.0.0.5")
+	if !got.IsPod() {
+		t.Fatalf("expected pod precedence; got class=%q", got.IdentityClass)
+	}
+}
+
+func TestResolveIP_FallbackClassification(t *testing.T) {
+	r := newSeededResolver()
+	cases := []struct {
+		name      string
+		ip        string
+		wantClass string
+	}{
+		{"empty-string", "", IdentityClassUnresolved},
+		{"invalid-ip", "not-an-ip", IdentityClassUnresolved},
+		{"loopback", "127.0.0.1", IdentityClassUnresolved},
+		{"unspecified", "0.0.0.0", IdentityClassUnresolved},
+		{"link-local", "169.254.1.1", IdentityClassUnresolved},
+		{"multicast", "224.0.0.1", IdentityClassUnresolved},
+		{"rfc1918-private-10", "10.99.0.1", IdentityClassUnresolved},
+		{"rfc1918-private-172", "172.20.0.1", IdentityClassUnresolved},
+		{"rfc1918-private-192", "192.168.99.1", IdentityClassUnresolved},
+		{"public-ipv4", "8.8.8.8", IdentityClassExternal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.ResolveIP(tc.ip)
+			if got.IdentityClass != tc.wantClass {
+				t.Errorf("ResolveIP(%q) class=%q want %q", tc.ip, got.IdentityClass, tc.wantClass)
+			}
+			if tc.ip != "" && got.PodIP != tc.ip {
+				t.Errorf("ResolveIP(%q) PodIP=%q want %q", tc.ip, got.PodIP, tc.ip)
+			}
+		})
+	}
+}
+
+func TestStrongerIdentity_RankWins(t *testing.T) {
+	weaker := PodIdentity{IdentityClass: IdentityClassUnresolved}
+	stronger := PodIdentity{IdentityClass: IdentityClassPod}
+
+	if got := StrongerIdentity(weaker, stronger); !got.IsPod() {
+		t.Fatalf("stronger candidate should win; got class=%q", got.IdentityClass)
+	}
+	if got := StrongerIdentity(stronger, weaker); !got.IsPod() {
+		t.Fatalf("stronger current should be kept; got class=%q", got.IdentityClass)
+	}
+}
+
+func TestStrongerIdentity_CompletenessTiebreak(t *testing.T) {
+	// 같은 IdentityClass(Pod)일 때 채워진 필드가 더 많은 쪽이 이긴다.
+	sparse := PodIdentity{IdentityClass: IdentityClassPod, PodIP: "10.0.0.1"}
+	rich := PodIdentity{IdentityClass: IdentityClassPod, Namespace: "default", PodName: "p1", PodUID: "uid1", PodIP: "10.0.0.1"}
+
+	got := StrongerIdentity(sparse, rich)
+	if got.PodName != "p1" {
+		t.Fatalf("richer candidate should win; got %+v", got)
+	}
+}
+
+func TestWithObservedIP(t *testing.T) {
+	id := PodIdentity{IdentityClass: IdentityClassPod, PodName: "p1"}
+
+	if got := WithObservedIP(id, "10.0.0.1"); got.PodIP != "10.0.0.1" {
+		t.Errorf("WithObservedIP should set PodIP; got %q", got.PodIP)
+	}
+	if got := WithObservedIP(id, ""); got.PodIP != "" {
+		t.Errorf("empty IP should not overwrite (here both empty); got %q", got.PodIP)
+	}
+
+	// 이미 PodIP가 채워진 식별에 빈 IP를 넘기면 그대로 보존되어야 한다.
+	idWithIP := PodIdentity{IdentityClass: IdentityClassPod, PodIP: "10.0.0.5"}
+	if got := WithObservedIP(idWithIP, ""); got.PodIP != "10.0.0.5" {
+		t.Errorf("empty IP must not clear existing PodIP; got %q", got.PodIP)
+	}
+}
+
+func TestNewResolver_NoConfigStillReturnsResolver(t *testing.T) {
+	// in-cluster 또는 kubeconfig 둘 다 없는 환경에서도 NewResolver가 nil을 반환하지 않고
+	// 비활성 Resolver를 반환해야 한다. Start 시 disabled 로그 후 반환되는 graceful path 전제다.
+	t.Setenv("KUBECONFIG", "/nonexistent/path")
+	t.Setenv("HOME", "/nonexistent-home")
+
+	r := NewResolver("test-node", 0)
+	if r == nil {
+		t.Fatal("NewResolver returned nil")
+	}
+	if r.LocalNode() != "test-node" {
+		t.Errorf("LocalNode=%q want test-node", r.LocalNode())
+	}
+	if r.HasSynced() {
+		t.Error("HasSynced should be false on a never-started resolver")
+	}
+}

--- a/internal/netobs/metadata/enricher.go
+++ b/internal/netobs/metadata/enricher.go
@@ -113,7 +113,7 @@ func (e *Enricher) lookupFlow(cookie uint64) (flowCacheEntry, bool) {
 //
 // rotate는 두 조건 중 하나만 만족해도 일어난다:
 //  1. 시간 기반: 마지막 rotate로부터 flowRotateEvery 경과
-//  2. 크기 기반: current 크기가 flowMaxCurrent 초과
+//  2. 크기 기반: current 크기가 flowMaxCurrent 이상
 //
 // 크기 기반 조기 rotate로 arrival rate 급증 시에도 peak 메모리가
 // 2 × flowMaxCurrent × entry_size로 상한된다.

--- a/internal/netobs/metadata/enricher.go
+++ b/internal/netobs/metadata/enricher.go
@@ -1,6 +1,6 @@
-// Package metadata는 netobs eBPF Event를 enrichment하기 위한 캐시 계층을 제공한다.
+// Package metadata는 netobs eBPF Event를 EnrichedEvent로 보강하는 캐시 계층을 제공한다.
 // IP→PodIdentity 인덱스와 informer는 internal/kube로 승격되어 있고, 본 패키지는 그 위에
-// netobs 고유의 socket-cookie flow 캐시와 cgroup/ifindex 런타임 hint 캐시를 얹는다.
+// netobs 고유의 socket-cookie flow 캐시와 cgroup/ifindex 런타임 hint 캐시를 얹어 Enrich 파이프라인을 구성한다.
 // 두 캐시는 eBPF 이벤트 stage 흐름과 결합되어 있어 공용 패키지로 옮기지 않는다.
 package metadata
 
@@ -23,12 +23,11 @@ type runtimeCacheEntry struct {
 	LastSeen time.Time
 }
 
-// Resolver는 *kube.Resolver를 embed해 IP→PodIdentity 해석을 위임하고,
+// Enricher는 *kube.Resolver를 명시 DI로 받아 IP→PodIdentity 해석을 위임하고,
 // 그 위에 netobs 고유의 flow / runtime hint 캐시와 Enrich 파이프라인을 보유한다.
-// embed된 kube.Resolver의 mu는 IP 인덱스만 보호하며, 본 구조체의 mu는 flow/runtime 캐시를 보호한다.
-// 두 mu가 분리되어 있어 IP 인덱스 갱신과 flow 캐시 lookup이 서로 블록되지 않는다.
-type Resolver struct {
-	*kube.Resolver
+// kube.Resolver의 lock과 본 구조체의 mu는 분리되어 IP 인덱스 갱신과 flow 캐시 lookup이 서로 블록되지 않는다.
+type Enricher struct {
+	kr *kube.Resolver
 
 	mu sync.RWMutex
 
@@ -52,12 +51,11 @@ type Resolver struct {
 	lastRuntimeSweep  time.Time
 }
 
-// NewResolver는 kube.Resolver를 구성한 뒤 netobs 전용 캐시를 함께 초기화한 metadata.Resolver를 반환한다.
-// 본 생성자는 호환성을 위해 기존 시그니처(localNode, resyncPeriod)를 유지하지만,
-// 호출부가 *kube.Resolver를 별도로 보유해야 한다면 다음 단계 refactor에서 명시 DI로 교체될 수 있다.
-func NewResolver(localNode string, resyncPeriod time.Duration) *Resolver {
-	return &Resolver{
-		Resolver: kube.NewResolver(localNode, resyncPeriod),
+// NewEnricher는 외부에서 구성된 *kube.Resolver를 받아 netobs 전용 캐시와 함께 Enricher를 구성한다.
+// IP→PodIdentity 인덱스의 lifecycle(Start/HasSynced)은 호출자가 kube.Resolver 측에서 관리한다.
+func NewEnricher(kr *kube.Resolver) *Enricher {
+	return &Enricher{
+		kr: kr,
 
 		// socket cookie flow cache (two-map generational).
 		// rotate 주기(2.5분)의 1~2배 범위에서 entry가 생존하므로
@@ -81,18 +79,18 @@ func NewResolver(localNode string, resyncPeriod time.Duration) *Resolver {
 // lookupFlow는 current 맵을 먼저 확인하고 miss면 previous 맵을 확인한다.
 // previous hit 시 해당 entry를 current로 promote해 다음 rotate에서
 // 만료되지 않도록 한다. promote를 위해 read lock을 write lock으로 승격한다.
-func (r *Resolver) lookupFlow(cookie uint64) (flowCacheEntry, bool) {
+func (e *Enricher) lookupFlow(cookie uint64) (flowCacheEntry, bool) {
 	if cookie == 0 {
 		return flowCacheEntry{}, false
 	}
 
-	r.mu.RLock()
-	if entry, ok := r.flowCurrent[cookie]; ok {
-		r.mu.RUnlock()
+	e.mu.RLock()
+	if entry, ok := e.flowCurrent[cookie]; ok {
+		e.mu.RUnlock()
 		return entry, true
 	}
-	entry, ok := r.flowPrevious[cookie]
-	r.mu.RUnlock()
+	entry, ok := e.flowPrevious[cookie]
+	e.mu.RUnlock()
 
 	if !ok {
 		return flowCacheEntry{}, false
@@ -101,11 +99,11 @@ func (r *Resolver) lookupFlow(cookie uint64) (flowCacheEntry, bool) {
 	// previous hit → current로 promote.
 	// RUnlock과 Lock 사이에 다른 goroutine이 먼저 promote했을 수 있으므로
 	// current에 이미 있다면 건너뛴다.
-	r.mu.Lock()
-	if _, already := r.flowCurrent[cookie]; !already {
-		r.flowCurrent[cookie] = entry
+	e.mu.Lock()
+	if _, already := e.flowCurrent[cookie]; !already {
+		e.flowCurrent[cookie] = entry
 	}
-	r.mu.Unlock()
+	e.mu.Unlock()
 
 	return entry, true
 }
@@ -119,19 +117,19 @@ func (r *Resolver) lookupFlow(cookie uint64) (flowCacheEntry, bool) {
 //
 // 크기 기반 조기 rotate로 arrival rate 급증 시에도 peak 메모리가
 // 2 × flowMaxCurrent × entry_size로 상한된다.
-func (r *Resolver) maybeRotateFlowsLocked(now time.Time) {
-	timeUp := now.Sub(r.lastFlowRotate) >= r.flowRotateEvery
-	sizeUp := len(r.flowCurrent) >= r.flowMaxCurrent
+func (e *Enricher) maybeRotateFlowsLocked(now time.Time) {
+	timeUp := now.Sub(e.lastFlowRotate) >= e.flowRotateEvery
+	sizeUp := len(e.flowCurrent) >= e.flowMaxCurrent
 	if !timeUp && !sizeUp {
 		return
 	}
 
-	r.flowPrevious = r.flowCurrent
-	r.flowCurrent = make(map[uint64]flowCacheEntry)
-	r.lastFlowRotate = now
+	e.flowPrevious = e.flowCurrent
+	e.flowCurrent = make(map[uint64]flowCacheEntry)
+	e.lastFlowRotate = now
 }
 
-func (r *Resolver) rememberFlow(cookie uint64, src, dst kube.PodIdentity, now time.Time) {
+func (e *Enricher) rememberFlow(cookie uint64, src, dst kube.PodIdentity, now time.Time) {
 	if cookie == 0 {
 		return
 	}
@@ -139,137 +137,137 @@ func (r *Resolver) rememberFlow(cookie uint64, src, dst kube.PodIdentity, now ti
 		return
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
-	r.maybeRotateFlowsLocked(now)
-	r.flowCurrent[cookie] = flowCacheEntry{
+	e.maybeRotateFlowsLocked(now)
+	e.flowCurrent[cookie] = flowCacheEntry{
 		Src: src,
 		Dst: dst,
 	}
 }
 
-func (r *Resolver) maybeSweepRuntimeLocked(now time.Time) {
-	if !r.lastRuntimeSweep.IsZero() && now.Sub(r.lastRuntimeSweep) < r.runtimeSweepEvery {
+func (e *Enricher) maybeSweepRuntimeLocked(now time.Time) {
+	if !e.lastRuntimeSweep.IsZero() && now.Sub(e.lastRuntimeSweep) < e.runtimeSweepEvery {
 		return
 	}
 
-	cutoff := now.Add(-r.runtimeTTL)
+	cutoff := now.Add(-e.runtimeTTL)
 
-	for k, v := range r.runtimeByCgroup {
+	for k, v := range e.runtimeByCgroup {
 		if v.LastSeen.Before(cutoff) {
-			delete(r.runtimeByCgroup, k)
+			delete(e.runtimeByCgroup, k)
 		}
 	}
-	for k, v := range r.runtimeByIfindex {
+	for k, v := range e.runtimeByIfindex {
 		if v.LastSeen.Before(cutoff) {
-			delete(r.runtimeByIfindex, k)
+			delete(e.runtimeByIfindex, k)
 		}
 	}
 
-	r.lastRuntimeSweep = now
+	e.lastRuntimeSweep = now
 }
 
-func (r *Resolver) lookupCgroupHint(cgroupID uint64, now time.Time) (kube.PodIdentity, bool) {
+func (e *Enricher) lookupCgroupHint(cgroupID uint64, now time.Time) (kube.PodIdentity, bool) {
 	if cgroupID == 0 {
 		return kube.PodIdentity{}, false
 	}
 
-	r.mu.RLock()
-	entry, ok := r.runtimeByCgroup[cgroupID]
-	r.mu.RUnlock()
+	e.mu.RLock()
+	entry, ok := e.runtimeByCgroup[cgroupID]
+	e.mu.RUnlock()
 
-	if !ok || now.Sub(entry.LastSeen) > r.runtimeTTL {
+	if !ok || now.Sub(entry.LastSeen) > e.runtimeTTL {
 		return kube.PodIdentity{}, false
 	}
 	return entry.ID, true
 }
 
-func (r *Resolver) lookupIfindexHint(ifindex uint32, now time.Time) (kube.PodIdentity, bool) {
+func (e *Enricher) lookupIfindexHint(ifindex uint32, now time.Time) (kube.PodIdentity, bool) {
 	if ifindex == 0 {
 		return kube.PodIdentity{}, false
 	}
 
-	r.mu.RLock()
-	entry, ok := r.runtimeByIfindex[ifindex]
-	r.mu.RUnlock()
+	e.mu.RLock()
+	entry, ok := e.runtimeByIfindex[ifindex]
+	e.mu.RUnlock()
 
-	if !ok || now.Sub(entry.LastSeen) > r.runtimeTTL {
+	if !ok || now.Sub(entry.LastSeen) > e.runtimeTTL {
 		return kube.PodIdentity{}, false
 	}
 	return entry.ID, true
 }
 
-func (r *Resolver) rememberCgroupHint(cgroupID uint64, id kube.PodIdentity, now time.Time) {
+func (e *Enricher) rememberCgroupHint(cgroupID uint64, id kube.PodIdentity, now time.Time) {
 	if cgroupID == 0 || !id.IsPod() {
 		return
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
-	r.maybeSweepRuntimeLocked(now)
-	r.runtimeByCgroup[cgroupID] = runtimeCacheEntry{
+	e.maybeSweepRuntimeLocked(now)
+	e.runtimeByCgroup[cgroupID] = runtimeCacheEntry{
 		ID:       id,
 		LastSeen: now,
 	}
 }
 
-func (r *Resolver) rememberIfindexHint(ifindex uint32, id kube.PodIdentity, now time.Time) {
+func (e *Enricher) rememberIfindexHint(ifindex uint32, id kube.PodIdentity, now time.Time) {
 	if ifindex == 0 || !id.IsPod() {
 		return
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
-	r.maybeSweepRuntimeLocked(now)
-	r.runtimeByIfindex[ifindex] = runtimeCacheEntry{
+	e.maybeSweepRuntimeLocked(now)
+	e.runtimeByIfindex[ifindex] = runtimeCacheEntry{
 		ID:       id,
 		LastSeen: now,
 	}
 }
 
-func (r *Resolver) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, dst kube.PodIdentity, now time.Time) (kube.PodIdentity, kube.PodIdentity) {
+func (e *Enricher) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, dst kube.PodIdentity, now time.Time) (kube.PodIdentity, kube.PodIdentity) {
 	if !src.IsPod() {
-		if id, ok := r.lookupCgroupHint(ev.CgroupID, now); ok {
+		if id, ok := e.lookupCgroupHint(ev.CgroupID, now); ok {
 			src = kube.StrongerIdentity(src, kube.WithObservedIP(id, srcIP))
 		}
 	}
 	if !src.IsPod() && ev.Ifindex != 0 {
-		if id, ok := r.lookupIfindexHint(ev.Ifindex, now); ok {
+		if id, ok := e.lookupIfindexHint(ev.Ifindex, now); ok {
 			src = kube.StrongerIdentity(src, kube.WithObservedIP(id, srcIP))
 		}
 	}
 	if !dst.IsPod() && ev.SkbIif != 0 {
-		if id, ok := r.lookupIfindexHint(ev.SkbIif, now); ok {
+		if id, ok := e.lookupIfindexHint(ev.SkbIif, now); ok {
 			dst = kube.StrongerIdentity(dst, kube.WithObservedIP(id, dstIP))
 		}
 	}
 	return src, dst
 }
 
-func (r *Resolver) rememberRuntimeHints(ev types.Event, src, dst kube.PodIdentity, now time.Time) {
+func (e *Enricher) rememberRuntimeHints(ev types.Event, src, dst kube.PodIdentity, now time.Time) {
 	switch ev.Stage {
 	case types.StageSendmsgRet:
 		if src.IsPod() {
-			r.rememberCgroupHint(ev.CgroupID, src, now)
+			e.rememberCgroupHint(ev.CgroupID, src, now)
 		}
 
 	case types.StageToVeth, types.StageToDevQ:
 		if src.IsPod() {
-			r.rememberCgroupHint(ev.CgroupID, src, now)
-			r.rememberIfindexHint(ev.Ifindex, src, now)
+			e.rememberCgroupHint(ev.CgroupID, src, now)
+			e.rememberIfindexHint(ev.Ifindex, src, now)
 		}
 
 	case types.StageRetrans, types.StageDrop:
 		if src.IsPod() {
-			r.rememberIfindexHint(ev.Ifindex, src, now)
+			e.rememberIfindexHint(ev.Ifindex, src, now)
 		}
 	}
 
 	if dst.IsPod() && ev.SkbIif != 0 {
-		r.rememberIfindexHint(ev.SkbIif, dst, now)
+		e.rememberIfindexHint(ev.SkbIif, dst, now)
 	}
 }
 
@@ -338,32 +336,32 @@ func deriveTrafficScope(src, dst kube.PodIdentity) string {
 }
 
 // Enrich는 raw eBPF Event를 EnrichedEvent로 보강한다.
-// IP 해석은 embed된 kube.Resolver에 위임하고, 그 결과에 socket-cookie flow 캐시 hit과
+// IP 해석은 주입된 *kube.Resolver에 위임하고, 그 결과에 socket-cookie flow 캐시 hit과
 // cgroup/ifindex runtime hint를 합쳐 양 끝의 식별을 가능한 강하게 만든다.
-func (r *Resolver) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEvent {
+func (e *Enricher) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEvent {
 	srcIP := types.U32ToIPv4(ev.Saddr)
 	dstIP := types.U32ToIPv4(ev.Daddr)
 
 	now := time.Now()
 
-	src := r.ResolveIP(srcIP)
-	dst := r.ResolveIP(dstIP)
+	src := e.kr.ResolveIP(srcIP)
+	dst := e.kr.ResolveIP(dstIP)
 
-	if cached, ok := r.lookupFlow(ev.SocketCookie); ok {
+	if cached, ok := e.lookupFlow(ev.SocketCookie); ok {
 		src = kube.StrongerIdentity(src, kube.WithObservedIP(cached.Src, srcIP))
 		dst = kube.StrongerIdentity(dst, kube.WithObservedIP(cached.Dst, dstIP))
 	}
 
-	src, dst = r.applyRuntimeHints(ev, srcIP, dstIP, src, dst, now)
+	src, dst = e.applyRuntimeHints(ev, srcIP, dstIP, src, dst, now)
 
 	if src.Known() {
 		switch ev.Stage {
 		case types.StageSendmsgRet, types.StageToVeth, types.StageToDevQ, types.StageRetrans, types.StageDrop:
-			r.rememberFlow(ev.SocketCookie, src, dst, now)
+			e.rememberFlow(ev.SocketCookie, src, dst, now)
 		}
 	}
 
-	r.rememberRuntimeHints(ev, src, dst, now)
+	e.rememberRuntimeHints(ev, src, dst, now)
 
 	reasonName := ""
 	reasonCategory := ""
@@ -377,7 +375,7 @@ func (r *Resolver) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEve
 		CommText:       types.CommString(ev.Comm),
 		Direction:      "egress",
 		TrafficScope:   deriveTrafficScope(src, dst),
-		ObservedNode:   r.LocalNode(),
+		ObservedNode:   e.kr.LocalNode(),
 		SrcIPText:      srcIP,
 		DstIPText:      dstIP,
 		Src:            src,

--- a/internal/netobs/metadata/resolver.go
+++ b/internal/netobs/metadata/resolver.go
@@ -19,27 +19,28 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"netobs/internal/kube"
 	"netobs/internal/netobs/drop"
 	"netobs/internal/netobs/types"
 )
 
 type podCacheEntry struct {
 	key string
-	id  types.PodIdentity
+	id  kube.PodIdentity
 }
 
 type serviceCacheEntry struct {
 	key string
-	id  types.PodIdentity
+	id  kube.PodIdentity
 }
 
 type flowCacheEntry struct {
-	Src types.PodIdentity
-	Dst types.PodIdentity
+	Src kube.PodIdentity
+	Dst kube.PodIdentity
 }
 
 type runtimeCacheEntry struct {
-	ID       types.PodIdentity
+	ID       kube.PodIdentity
 	LastSeen time.Time
 }
 
@@ -529,11 +530,11 @@ func nodeIPs(n corev1.Node) []string {
 	return out
 }
 
-func podIdentity(p corev1.Pod) types.PodIdentity {
+func podIdentity(p corev1.Pod) kube.PodIdentity {
 	kind, workload := ownerInfo(p)
 
-	return types.PodIdentity{
-		IdentityClass: types.IdentityClassPod,
+	return kube.PodIdentity{
+		IdentityClass: kube.IdentityClassPod,
 		Namespace:     p.Namespace,
 		PodUID:        string(p.UID),
 		PodName:       p.Name,
@@ -544,9 +545,9 @@ func podIdentity(p corev1.Pod) types.PodIdentity {
 	}
 }
 
-func serviceIdentity(s corev1.Service) types.PodIdentity {
-	return types.PodIdentity{
-		IdentityClass: types.IdentityClassService,
+func serviceIdentity(s corev1.Service) kube.PodIdentity {
+	return kube.PodIdentity{
+		IdentityClass: kube.IdentityClassService,
 		Namespace:     s.Namespace,
 		WorkloadKind:  "Service",
 		Workload:      s.Name,
@@ -554,9 +555,9 @@ func serviceIdentity(s corev1.Service) types.PodIdentity {
 	}
 }
 
-func nodeIdentity(nodeName, ip string) types.PodIdentity {
-	return types.PodIdentity{
-		IdentityClass: types.IdentityClassNode,
+func nodeIdentity(nodeName, ip string) kube.PodIdentity {
+	return kube.PodIdentity{
+		IdentityClass: kube.IdentityClassNode,
 		NodeName:      nodeName,
 		WorkloadKind:  "Node",
 		Workload:      nodeName,
@@ -564,18 +565,18 @@ func nodeIdentity(nodeName, ip string) types.PodIdentity {
 	}
 }
 
-func externalIdentity(ip string) types.PodIdentity {
-	return types.PodIdentity{
-		IdentityClass: types.IdentityClassExternal,
+func externalIdentity(ip string) kube.PodIdentity {
+	return kube.PodIdentity{
+		IdentityClass: kube.IdentityClassExternal,
 		WorkloadKind:  "External",
 		Workload:      "external",
 		PodIP:         ip,
 	}
 }
 
-func unresolvedIdentity(ip string) types.PodIdentity {
-	return types.PodIdentity{
-		IdentityClass: types.IdentityClassUnresolved,
+func unresolvedIdentity(ip string) kube.PodIdentity {
+	return kube.PodIdentity{
+		IdentityClass: kube.IdentityClassUnresolved,
 		WorkloadKind:  "Unresolved",
 		Workload:      "unresolved",
 		PodIP:         ip,
@@ -592,7 +593,7 @@ func ownerInfo(p corev1.Pod) (string, string) {
 	name := owner.Name
 
 	if kind == "ReplicaSet" {
-		if dep := types.TrimGeneratedSuffix(name); dep != "" {
+		if dep := kube.TrimGeneratedSuffix(name); dep != "" {
 			return "Deployment", dep
 		}
 	}
@@ -602,7 +603,7 @@ func ownerInfo(p corev1.Pod) (string, string) {
 
 // identityCompleteness는 식별 필드가 얼마나 채워졌는지 점수화한다.
 // 같은 IdentityClass 내에서 tiebreak 용도로만 쓰인다.
-func identityCompleteness(p types.PodIdentity) int {
+func identityCompleteness(p kube.PodIdentity) int {
 	score := 0
 	if p.Namespace != "" {
 		score++
@@ -628,7 +629,7 @@ func identityCompleteness(p types.PodIdentity) int {
 	return score
 }
 
-func strongerIdentity(current, candidate types.PodIdentity) types.PodIdentity {
+func strongerIdentity(current, candidate kube.PodIdentity) kube.PodIdentity {
 	if candidate.Rank() > current.Rank() {
 		return candidate
 	}
@@ -642,7 +643,7 @@ func strongerIdentity(current, candidate types.PodIdentity) types.PodIdentity {
 	return current
 }
 
-func withObservedIP(id types.PodIdentity, ip string) types.PodIdentity {
+func withObservedIP(id kube.PodIdentity, ip string) kube.PodIdentity {
 	if ip != "" {
 		id.PodIP = ip
 	}
@@ -702,7 +703,7 @@ func (r *Resolver) maybeRotateFlowsLocked(now time.Time) {
 	r.lastFlowRotate = now
 }
 
-func (r *Resolver) rememberFlow(cookie uint64, src, dst types.PodIdentity, now time.Time) {
+func (r *Resolver) rememberFlow(cookie uint64, src, dst kube.PodIdentity, now time.Time) {
 	if cookie == 0 {
 		return
 	}
@@ -720,7 +721,7 @@ func (r *Resolver) rememberFlow(cookie uint64, src, dst types.PodIdentity, now t
 	}
 }
 
-func (r *Resolver) resolveIP(ip string) types.PodIdentity {
+func (r *Resolver) resolveIP(ip string) kube.PodIdentity {
 	if ip == "" {
 		return unresolvedIdentity(ip)
 	}
@@ -761,9 +762,9 @@ func (r *Resolver) maybeSweepRuntimeLocked(now time.Time) {
 	r.lastRuntimeSweep = now
 }
 
-func (r *Resolver) lookupCgroupHint(cgroupID uint64, now time.Time) (types.PodIdentity, bool) {
+func (r *Resolver) lookupCgroupHint(cgroupID uint64, now time.Time) (kube.PodIdentity, bool) {
 	if cgroupID == 0 {
-		return types.PodIdentity{}, false
+		return kube.PodIdentity{}, false
 	}
 
 	r.mu.RLock()
@@ -771,14 +772,14 @@ func (r *Resolver) lookupCgroupHint(cgroupID uint64, now time.Time) (types.PodId
 	r.mu.RUnlock()
 
 	if !ok || now.Sub(entry.LastSeen) > r.runtimeTTL {
-		return types.PodIdentity{}, false
+		return kube.PodIdentity{}, false
 	}
 	return entry.ID, true
 }
 
-func (r *Resolver) lookupIfindexHint(ifindex uint32, now time.Time) (types.PodIdentity, bool) {
+func (r *Resolver) lookupIfindexHint(ifindex uint32, now time.Time) (kube.PodIdentity, bool) {
 	if ifindex == 0 {
-		return types.PodIdentity{}, false
+		return kube.PodIdentity{}, false
 	}
 
 	r.mu.RLock()
@@ -786,12 +787,12 @@ func (r *Resolver) lookupIfindexHint(ifindex uint32, now time.Time) (types.PodId
 	r.mu.RUnlock()
 
 	if !ok || now.Sub(entry.LastSeen) > r.runtimeTTL {
-		return types.PodIdentity{}, false
+		return kube.PodIdentity{}, false
 	}
 	return entry.ID, true
 }
 
-func (r *Resolver) rememberCgroupHint(cgroupID uint64, id types.PodIdentity, now time.Time) {
+func (r *Resolver) rememberCgroupHint(cgroupID uint64, id kube.PodIdentity, now time.Time) {
 	if cgroupID == 0 || !id.IsPod() {
 		return
 	}
@@ -806,7 +807,7 @@ func (r *Resolver) rememberCgroupHint(cgroupID uint64, id types.PodIdentity, now
 	}
 }
 
-func (r *Resolver) rememberIfindexHint(ifindex uint32, id types.PodIdentity, now time.Time) {
+func (r *Resolver) rememberIfindexHint(ifindex uint32, id kube.PodIdentity, now time.Time) {
 	if ifindex == 0 || !id.IsPod() {
 		return
 	}
@@ -821,7 +822,7 @@ func (r *Resolver) rememberIfindexHint(ifindex uint32, id types.PodIdentity, now
 	}
 }
 
-func (r *Resolver) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, dst types.PodIdentity, now time.Time) (types.PodIdentity, types.PodIdentity) {
+func (r *Resolver) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, dst kube.PodIdentity, now time.Time) (kube.PodIdentity, kube.PodIdentity) {
 	if !src.IsPod() {
 		if id, ok := r.lookupCgroupHint(ev.CgroupID, now); ok {
 			src = strongerIdentity(src, withObservedIP(id, srcIP))
@@ -840,7 +841,7 @@ func (r *Resolver) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, d
 	return src, dst
 }
 
-func (r *Resolver) rememberRuntimeHints(ev types.Event, src, dst types.PodIdentity, now time.Time) {
+func (r *Resolver) rememberRuntimeHints(ev types.Event, src, dst kube.PodIdentity, now time.Time) {
 	switch ev.Stage {
 	case types.StageSendmsgRet:
 		if src.IsPod() {
@@ -864,7 +865,7 @@ func (r *Resolver) rememberRuntimeHints(ev types.Event, src, dst types.PodIdenti
 	}
 }
 
-func classifyFallbackIP(ip string) types.PodIdentity {
+func classifyFallbackIP(ip string) kube.PodIdentity {
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
 		return unresolvedIdentity(ip)
@@ -884,7 +885,7 @@ func classifyFallbackIP(ip string) types.PodIdentity {
 	return externalIdentity(ip)
 }
 
-func deriveTrafficScope(src, dst types.PodIdentity) string {
+func deriveTrafficScope(src, dst kube.PodIdentity) string {
 	switch {
 	case src.IsPod() && dst.IsPod():
 		if src.NodeName != "" && dst.NodeName != "" {

--- a/internal/netobs/metadata/resolver.go
+++ b/internal/netobs/metadata/resolver.go
@@ -1,38 +1,17 @@
+// Package metadata는 netobs eBPF Event를 enrichment하기 위한 캐시 계층을 제공한다.
+// IP→PodIdentity 인덱스와 informer는 internal/kube로 승격되어 있고, 본 패키지는 그 위에
+// netobs 고유의 socket-cookie flow 캐시와 cgroup/ifindex 런타임 hint 캐시를 얹는다.
+// 두 캐시는 eBPF 이벤트 stage 흐름과 결합되어 있어 공용 패키지로 옮기지 않는다.
 package metadata
 
 import (
-	"context"
-	"errors"
-	"log"
-	"net/netip"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"netobs/internal/kube"
 	"netobs/internal/netobs/drop"
 	"netobs/internal/netobs/types"
 )
-
-type podCacheEntry struct {
-	key string
-	id  kube.PodIdentity
-}
-
-type serviceCacheEntry struct {
-	key string
-	id  kube.PodIdentity
-}
 
 type flowCacheEntry struct {
 	Src kube.PodIdentity
@@ -44,24 +23,14 @@ type runtimeCacheEntry struct {
 	LastSeen time.Time
 }
 
+// Resolver는 *kube.Resolver를 embed해 IP→PodIdentity 해석을 위임하고,
+// 그 위에 netobs 고유의 flow / runtime hint 캐시와 Enrich 파이프라인을 보유한다.
+// embed된 kube.Resolver의 mu는 IP 인덱스만 보호하며, 본 구조체의 mu는 flow/runtime 캐시를 보호한다.
+// 두 mu가 분리되어 있어 IP 인덱스 갱신과 flow 캐시 lookup이 서로 블록되지 않는다.
 type Resolver struct {
-	localNode    string
-	client       kubernetes.Interface
-	startupErr   error
-	resyncPeriod time.Duration
-
-	synced atomic.Bool
+	*kube.Resolver
 
 	mu sync.RWMutex
-
-	podByIP     map[string]podCacheEntry
-	podIPsByKey map[string][]string
-
-	serviceByIP     map[string]serviceCacheEntry
-	serviceIPsByKey map[string][]string
-
-	nodeByIP     map[string]string
-	nodeIPsByKey map[string][]string
 
 	// socket cookie flow cache (two-map generational)
 	// 주기적으로 current → previous로 swap해 O(1) 만료를 수행한다.
@@ -83,16 +52,12 @@ type Resolver struct {
 	lastRuntimeSweep  time.Time
 }
 
+// NewResolver는 kube.Resolver를 구성한 뒤 netobs 전용 캐시를 함께 초기화한 metadata.Resolver를 반환한다.
+// 본 생성자는 호환성을 위해 기존 시그니처(localNode, resyncPeriod)를 유지하지만,
+// 호출부가 *kube.Resolver를 별도로 보유해야 한다면 다음 단계 refactor에서 명시 DI로 교체될 수 있다.
 func NewResolver(localNode string, resyncPeriod time.Duration) *Resolver {
-	r := &Resolver{
-		localNode:       localNode,
-		resyncPeriod:    resyncPeriod,
-		podByIP:         make(map[string]podCacheEntry),
-		podIPsByKey:     make(map[string][]string),
-		serviceByIP:     make(map[string]serviceCacheEntry),
-		serviceIPsByKey: make(map[string][]string),
-		nodeByIP:        make(map[string]string),
-		nodeIPsByKey:    make(map[string][]string),
+	return &Resolver{
+		Resolver: kube.NewResolver(localNode, resyncPeriod),
 
 		// socket cookie flow cache (two-map generational).
 		// rotate 주기(2.5분)의 1~2배 범위에서 entry가 생존하므로
@@ -111,543 +76,6 @@ func NewResolver(localNode string, resyncPeriod time.Duration) *Resolver {
 		runtimeTTL:        2 * time.Minute,
 		runtimeSweepEvery: 30 * time.Second,
 	}
-
-	cfg, err := kubeConfig()
-	if err != nil {
-		r.startupErr = err
-		return r
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		r.startupErr = err
-		return r
-	}
-
-	r.client = clientset
-	return r
-}
-
-func kubeConfig() (*rest.Config, error) {
-	if cfg, err := rest.InClusterConfig(); err == nil {
-		return cfg, nil
-	}
-
-	if kubeconfig := strings.TrimSpace(os.Getenv("KUBECONFIG")); kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
-	}
-
-	home, err := os.UserHomeDir()
-	if err == nil {
-		path := filepath.Join(home, ".kube", "config")
-		if _, statErr := os.Stat(path); statErr == nil {
-			return clientcmd.BuildConfigFromFlags("", path)
-		}
-	}
-
-	return nil, errors.New("no in-cluster config and no kubeconfig found")
-}
-
-func (r *Resolver) Start(ctx context.Context) {
-	if r.client == nil {
-		log.Printf("metadata resolver disabled: %v", r.startupErr)
-		return
-	}
-
-	factory := informers.NewSharedInformerFactory(r.client, r.resyncPeriod)
-
-	podInformer := factory.Core().V1().Pods().Informer()
-	serviceInformer := factory.Core().V1().Services().Informer()
-	nodeInformer := factory.Core().V1().Nodes().Informer()
-
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			r.onUpsertPod(obj)
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			r.onUpsertPod(newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			r.onDeletePod(obj)
-		},
-	})
-
-	serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			r.onUpsertService(obj)
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			r.onUpsertService(newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			r.onDeleteService(obj)
-		},
-	})
-
-	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			r.onUpsertNode(obj)
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			r.onUpsertNode(newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			r.onDeleteNode(obj)
-		},
-	})
-
-	factory.Start(ctx.Done())
-
-	if !cache.WaitForCacheSync(
-		ctx.Done(),
-		podInformer.HasSynced,
-		serviceInformer.HasSynced,
-		nodeInformer.HasSynced,
-	) {
-		log.Printf("metadata resolver initial sync failed")
-		return
-	}
-
-	r.synced.Store(true)
-	log.Printf("metadata resolver informer sync completed")
-
-	<-ctx.Done()
-}
-
-// HasSynced는 Kubernetes informer 캐시가 초기 sync를 완료했는지 반환한다.
-// client 초기화 실패로 resolver가 비활성 상태인 경우에도 false를 반환해
-// /readyz가 해당 상태를 드러내도록 한다.
-func (r *Resolver) HasSynced() bool {
-	return r.synced.Load()
-}
-
-func (r *Resolver) onUpsertPod(obj interface{}) {
-	pod, ok := extractPod(obj)
-	if !ok || pod == nil {
-		return
-	}
-
-	key := podKey(pod)
-	ips := podIPs(*pod)
-	id := podIdentity(*pod)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// 기존 IP 매핑 제거
-	if oldIPs, exists := r.podIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if entry, ok := r.podByIP[ip]; ok && entry.key == key {
-				delete(r.podByIP, ip)
-			}
-		}
-	}
-
-	// 현재 Pod에 IP가 없으면 캐시만 정리하고 종료
-	if len(ips) == 0 {
-		delete(r.podIPsByKey, key)
-		return
-	}
-
-	for _, ip := range ips {
-		r.podByIP[ip] = podCacheEntry{
-			key: key,
-			id:  id,
-		}
-	}
-	r.podIPsByKey[key] = ips
-}
-
-func (r *Resolver) onDeletePod(obj interface{}) {
-	pod, ok := extractPod(obj)
-	if !ok || pod == nil {
-		return
-	}
-
-	key := podKey(pod)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if oldIPs, exists := r.podIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if entry, ok := r.podByIP[ip]; ok && entry.key == key {
-				delete(r.podByIP, ip)
-			}
-		}
-		delete(r.podIPsByKey, key)
-		return
-	}
-
-	// fallback: tombstone만 있고 key 캐시가 없는 경우
-	for _, ip := range podIPs(*pod) {
-		if entry, ok := r.podByIP[ip]; ok && entry.key == key {
-			delete(r.podByIP, ip)
-		}
-	}
-}
-
-func (r *Resolver) onUpsertService(obj interface{}) {
-	svc, ok := extractService(obj)
-	if !ok || svc == nil {
-		return
-	}
-
-	key := serviceKey(svc)
-	ips := serviceIPs(*svc)
-	id := serviceIdentity(*svc)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if oldIPs, exists := r.serviceIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
-				delete(r.serviceByIP, ip)
-			}
-		}
-	}
-
-	if len(ips) == 0 {
-		delete(r.serviceIPsByKey, key)
-		return
-	}
-
-	for _, ip := range ips {
-		r.serviceByIP[ip] = serviceCacheEntry{
-			key: key,
-			id:  id,
-		}
-	}
-	r.serviceIPsByKey[key] = ips
-}
-
-func (r *Resolver) onDeleteService(obj interface{}) {
-	svc, ok := extractService(obj)
-	if !ok || svc == nil {
-		return
-	}
-
-	key := serviceKey(svc)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if oldIPs, exists := r.serviceIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
-				delete(r.serviceByIP, ip)
-			}
-		}
-		delete(r.serviceIPsByKey, key)
-		return
-	}
-
-	for _, ip := range serviceIPs(*svc) {
-		if entry, ok := r.serviceByIP[ip]; ok && entry.key == key {
-			delete(r.serviceByIP, ip)
-		}
-	}
-}
-
-func (r *Resolver) onUpsertNode(obj interface{}) {
-	node, ok := extractNode(obj)
-	if !ok || node == nil {
-		return
-	}
-
-	key := nodeKey(node)
-	ips := nodeIPs(*node)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if oldIPs, exists := r.nodeIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
-				delete(r.nodeByIP, ip)
-			}
-		}
-	}
-
-	if len(ips) == 0 {
-		delete(r.nodeIPsByKey, key)
-		return
-	}
-
-	for _, ip := range ips {
-		r.nodeByIP[ip] = node.Name
-	}
-	r.nodeIPsByKey[key] = ips
-}
-
-func (r *Resolver) onDeleteNode(obj interface{}) {
-	node, ok := extractNode(obj)
-	if !ok || node == nil {
-		return
-	}
-
-	key := nodeKey(node)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if oldIPs, exists := r.nodeIPsByKey[key]; exists {
-		for _, ip := range oldIPs {
-			if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
-				delete(r.nodeByIP, ip)
-			}
-		}
-		delete(r.nodeIPsByKey, key)
-		return
-	}
-
-	for _, ip := range nodeIPs(*node) {
-		if name, ok := r.nodeByIP[ip]; ok && name == node.Name {
-			delete(r.nodeByIP, ip)
-		}
-	}
-}
-
-func extractPod(obj interface{}) (*corev1.Pod, bool) {
-	switch t := obj.(type) {
-	case *corev1.Pod:
-		return t, true
-	case cache.DeletedFinalStateUnknown:
-		pod, ok := t.Obj.(*corev1.Pod)
-		return pod, ok
-	default:
-		return nil, false
-	}
-}
-
-func extractService(obj interface{}) (*corev1.Service, bool) {
-	switch t := obj.(type) {
-	case *corev1.Service:
-		return t, true
-	case cache.DeletedFinalStateUnknown:
-		svc, ok := t.Obj.(*corev1.Service)
-		return svc, ok
-	default:
-		return nil, false
-	}
-}
-
-func extractNode(obj interface{}) (*corev1.Node, bool) {
-	switch t := obj.(type) {
-	case *corev1.Node:
-		return t, true
-	case cache.DeletedFinalStateUnknown:
-		node, ok := t.Obj.(*corev1.Node)
-		return node, ok
-	default:
-		return nil, false
-	}
-}
-
-func podKey(p *corev1.Pod) string {
-	if p.UID != "" {
-		return string(p.UID)
-	}
-	return p.Namespace + "/" + p.Name
-}
-
-func serviceKey(s *corev1.Service) string {
-	if s.UID != "" {
-		return string(s.UID)
-	}
-	return s.Namespace + "/" + s.Name
-}
-
-func nodeKey(n *corev1.Node) string {
-	if n.UID != "" {
-		return string(n.UID)
-	}
-	return n.Name
-}
-
-func podIPs(p corev1.Pod) []string {
-	seen := make(map[string]struct{}, 1+len(p.Status.PodIPs))
-	out := make([]string, 0, 1+len(p.Status.PodIPs))
-
-	if p.Status.PodIP != "" {
-		seen[p.Status.PodIP] = struct{}{}
-		out = append(out, p.Status.PodIP)
-	}
-
-	for _, pip := range p.Status.PodIPs {
-		if pip.IP == "" {
-			continue
-		}
-		if _, exists := seen[pip.IP]; exists {
-			continue
-		}
-		seen[pip.IP] = struct{}{}
-		out = append(out, pip.IP)
-	}
-
-	return out
-}
-
-func serviceIPs(s corev1.Service) []string {
-	seen := make(map[string]struct{}, 1+len(s.Spec.ClusterIPs))
-	out := make([]string, 0, 1+len(s.Spec.ClusterIPs))
-
-	if s.Spec.ClusterIP != "" && s.Spec.ClusterIP != "None" {
-		seen[s.Spec.ClusterIP] = struct{}{}
-		out = append(out, s.Spec.ClusterIP)
-	}
-
-	for _, ip := range s.Spec.ClusterIPs {
-		if ip == "" || ip == "None" {
-			continue
-		}
-		if _, exists := seen[ip]; exists {
-			continue
-		}
-		seen[ip] = struct{}{}
-		out = append(out, ip)
-	}
-
-	return out
-}
-
-func nodeIPs(n corev1.Node) []string {
-	seen := make(map[string]struct{}, len(n.Status.Addresses))
-	out := make([]string, 0, len(n.Status.Addresses))
-
-	for _, addr := range n.Status.Addresses {
-		if addr.Address == "" {
-			continue
-		}
-		if _, exists := seen[addr.Address]; exists {
-			continue
-		}
-		seen[addr.Address] = struct{}{}
-		out = append(out, addr.Address)
-	}
-
-	return out
-}
-
-func podIdentity(p corev1.Pod) kube.PodIdentity {
-	kind, workload := ownerInfo(p)
-
-	return kube.PodIdentity{
-		IdentityClass: kube.IdentityClassPod,
-		Namespace:     p.Namespace,
-		PodUID:        string(p.UID),
-		PodName:       p.Name,
-		NodeName:      p.Spec.NodeName,
-		WorkloadKind:  kind,
-		Workload:      workload,
-		PodIP:         p.Status.PodIP,
-	}
-}
-
-func serviceIdentity(s corev1.Service) kube.PodIdentity {
-	return kube.PodIdentity{
-		IdentityClass: kube.IdentityClassService,
-		Namespace:     s.Namespace,
-		WorkloadKind:  "Service",
-		Workload:      s.Name,
-		PodIP:         s.Spec.ClusterIP,
-	}
-}
-
-func nodeIdentity(nodeName, ip string) kube.PodIdentity {
-	return kube.PodIdentity{
-		IdentityClass: kube.IdentityClassNode,
-		NodeName:      nodeName,
-		WorkloadKind:  "Node",
-		Workload:      nodeName,
-		PodIP:         ip,
-	}
-}
-
-func externalIdentity(ip string) kube.PodIdentity {
-	return kube.PodIdentity{
-		IdentityClass: kube.IdentityClassExternal,
-		WorkloadKind:  "External",
-		Workload:      "external",
-		PodIP:         ip,
-	}
-}
-
-func unresolvedIdentity(ip string) kube.PodIdentity {
-	return kube.PodIdentity{
-		IdentityClass: kube.IdentityClassUnresolved,
-		WorkloadKind:  "Unresolved",
-		Workload:      "unresolved",
-		PodIP:         ip,
-	}
-}
-
-func ownerInfo(p corev1.Pod) (string, string) {
-	if len(p.OwnerReferences) == 0 {
-		return "Pod", p.Name
-	}
-
-	owner := p.OwnerReferences[0]
-	kind := owner.Kind
-	name := owner.Name
-
-	if kind == "ReplicaSet" {
-		if dep := kube.TrimGeneratedSuffix(name); dep != "" {
-			return "Deployment", dep
-		}
-	}
-
-	return kind, name
-}
-
-// identityCompleteness는 식별 필드가 얼마나 채워졌는지 점수화한다.
-// 같은 IdentityClass 내에서 tiebreak 용도로만 쓰인다.
-func identityCompleteness(p kube.PodIdentity) int {
-	score := 0
-	if p.Namespace != "" {
-		score++
-	}
-	if p.PodUID != "" {
-		score++
-	}
-	if p.PodName != "" {
-		score++
-	}
-	if p.NodeName != "" {
-		score++
-	}
-	if p.Workload != "" {
-		score++
-	}
-	if p.WorkloadKind != "" {
-		score++
-	}
-	if p.PodIP != "" {
-		score++
-	}
-	return score
-}
-
-func strongerIdentity(current, candidate kube.PodIdentity) kube.PodIdentity {
-	if candidate.Rank() > current.Rank() {
-		return candidate
-	}
-	if current.Rank() > candidate.Rank() {
-		return current
-	}
-
-	if identityCompleteness(candidate) > identityCompleteness(current) {
-		return candidate
-	}
-	return current
-}
-
-func withObservedIP(id kube.PodIdentity, ip string) kube.PodIdentity {
-	if ip != "" {
-		id.PodIP = ip
-	}
-	return id
 }
 
 // lookupFlow는 current 맵을 먼저 확인하고 miss면 previous 맵을 확인한다.
@@ -719,26 +147,6 @@ func (r *Resolver) rememberFlow(cookie uint64, src, dst kube.PodIdentity, now ti
 		Src: src,
 		Dst: dst,
 	}
-}
-
-func (r *Resolver) resolveIP(ip string) kube.PodIdentity {
-	if ip == "" {
-		return unresolvedIdentity(ip)
-	}
-
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	if entry, ok := r.podByIP[ip]; ok {
-		return entry.id
-	}
-	if entry, ok := r.serviceByIP[ip]; ok {
-		return entry.id
-	}
-	if nodeName, ok := r.nodeByIP[ip]; ok {
-		return nodeIdentity(nodeName, ip)
-	}
-	return classifyFallbackIP(ip)
 }
 
 func (r *Resolver) maybeSweepRuntimeLocked(now time.Time) {
@@ -825,17 +233,17 @@ func (r *Resolver) rememberIfindexHint(ifindex uint32, id kube.PodIdentity, now 
 func (r *Resolver) applyRuntimeHints(ev types.Event, srcIP, dstIP string, src, dst kube.PodIdentity, now time.Time) (kube.PodIdentity, kube.PodIdentity) {
 	if !src.IsPod() {
 		if id, ok := r.lookupCgroupHint(ev.CgroupID, now); ok {
-			src = strongerIdentity(src, withObservedIP(id, srcIP))
+			src = kube.StrongerIdentity(src, kube.WithObservedIP(id, srcIP))
 		}
 	}
 	if !src.IsPod() && ev.Ifindex != 0 {
 		if id, ok := r.lookupIfindexHint(ev.Ifindex, now); ok {
-			src = strongerIdentity(src, withObservedIP(id, srcIP))
+			src = kube.StrongerIdentity(src, kube.WithObservedIP(id, srcIP))
 		}
 	}
 	if !dst.IsPod() && ev.SkbIif != 0 {
 		if id, ok := r.lookupIfindexHint(ev.SkbIif, now); ok {
-			dst = strongerIdentity(dst, withObservedIP(id, dstIP))
+			dst = kube.StrongerIdentity(dst, kube.WithObservedIP(id, dstIP))
 		}
 	}
 	return src, dst
@@ -863,26 +271,6 @@ func (r *Resolver) rememberRuntimeHints(ev types.Event, src, dst kube.PodIdentit
 	if dst.IsPod() && ev.SkbIif != 0 {
 		r.rememberIfindexHint(ev.SkbIif, dst, now)
 	}
-}
-
-func classifyFallbackIP(ip string) kube.PodIdentity {
-	addr, err := netip.ParseAddr(ip)
-	if err != nil {
-		return unresolvedIdentity(ip)
-	}
-
-	if addr.IsUnspecified() || addr.IsLoopback() || addr.IsMulticast() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
-		return unresolvedIdentity(ip)
-	}
-
-	// RFC1918 / ULA 등 private 주소인데 pod/service/node 어느 쪽에도 매핑되지 않음
-	// -> cluster 내부 또는 host 내부일 가능성이 높으므로 unresolved로 정리
-	if addr.IsPrivate() {
-		return unresolvedIdentity(ip)
-	}
-
-	// public IP면 external로 분류
-	return externalIdentity(ip)
 }
 
 func deriveTrafficScope(src, dst kube.PodIdentity) string {
@@ -949,18 +337,21 @@ func deriveTrafficScope(src, dst kube.PodIdentity) string {
 	}
 }
 
+// Enrich는 raw eBPF Event를 EnrichedEvent로 보강한다.
+// IP 해석은 embed된 kube.Resolver에 위임하고, 그 결과에 socket-cookie flow 캐시 hit과
+// cgroup/ifindex runtime hint를 합쳐 양 끝의 식별을 가능한 강하게 만든다.
 func (r *Resolver) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEvent {
 	srcIP := types.U32ToIPv4(ev.Saddr)
 	dstIP := types.U32ToIPv4(ev.Daddr)
 
 	now := time.Now()
 
-	src := r.resolveIP(srcIP)
-	dst := r.resolveIP(dstIP)
+	src := r.ResolveIP(srcIP)
+	dst := r.ResolveIP(dstIP)
 
 	if cached, ok := r.lookupFlow(ev.SocketCookie); ok {
-		src = strongerIdentity(src, withObservedIP(cached.Src, srcIP))
-		dst = strongerIdentity(dst, withObservedIP(cached.Dst, dstIP))
+		src = kube.StrongerIdentity(src, kube.WithObservedIP(cached.Src, srcIP))
+		dst = kube.StrongerIdentity(dst, kube.WithObservedIP(cached.Dst, dstIP))
 	}
 
 	src, dst = r.applyRuntimeHints(ev, srcIP, dstIP, src, dst, now)
@@ -986,7 +377,7 @@ func (r *Resolver) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEve
 		CommText:       types.CommString(ev.Comm),
 		Direction:      "egress",
 		TrafficScope:   deriveTrafficScope(src, dst),
-		ObservedNode:   r.localNode,
+		ObservedNode:   r.LocalNode(),
 		SrcIPText:      srcIP,
 		DstIPText:      dstIP,
 		Src:            src,

--- a/internal/netobs/metrics/metrics.go
+++ b/internal/netobs/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"netobs/internal/kube"
 	"netobs/internal/netobs/types"
 )
 
@@ -118,14 +119,14 @@ func label(v string) string {
 	return v
 }
 
-func podNameLabel(p types.PodIdentity) string {
+func podNameLabel(p kube.PodIdentity) string {
 	if p.PodName != "" {
 		return p.PodName
 	}
 	return "unknown"
 }
 
-func podUIDLabel(p types.PodIdentity) string {
+func podUIDLabel(p kube.PodIdentity) string {
 	if p.PodUID != "" {
 		return p.PodUID
 	}

--- a/internal/netobs/types/event.go
+++ b/internal/netobs/types/event.go
@@ -1,11 +1,14 @@
+// Package types는 netobs eBPF 이벤트 모델과 enrichment 결과를 정의한다.
+// PodIdentity 등 클러스터 식별 모델은 netobs/gpuobs 공용 패키지인 internal/kube에 있으며,
+// 본 패키지는 그 위에 eBPF stage/이벤트 표현을 얹는 역할만 한다.
 package types
 
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"net"
-	"strings"
+
+	"netobs/internal/kube"
 )
 
 const (
@@ -14,14 +17,6 @@ const (
 	StageToDevQ     = 3
 	StageRetrans    = 4
 	StageDrop       = 5
-)
-
-const (
-	IdentityClassPod        = "pod"
-	IdentityClassNode       = "node"
-	IdentityClassService    = "service"
-	IdentityClassExternal   = "external"
-	IdentityClassUnresolved = "unresolved"
 )
 
 type Event struct {
@@ -56,248 +51,14 @@ type EnrichedEvent struct {
 	ObservedNode   string
 	SrcIPText      string
 	DstIPText      string
-	Src            PodIdentity
-	Dst            PodIdentity
+	Src            kube.PodIdentity
+	Dst            kube.PodIdentity
 	DropReasonName string
 	DropCategory   string
 }
 
-type PodIdentity struct {
-	IdentityClass string
-	Namespace     string
-	PodUID        string
-	PodName       string
-	NodeName      string
-	WorkloadKind  string
-	Workload      string
-	PodIP         string
-}
-
-// --------------------- PodIdentity 관련 메서드 ---------------------
-func (p PodIdentity) Known() bool {
-	return !p.IsUnresolved()
-}
-
-func (p PodIdentity) IsPod() bool {
-	return p.IdentityClass == IdentityClassPod
-}
-
-func (p PodIdentity) IsNode() bool {
-	return p.IdentityClass == IdentityClassNode
-}
-
-func (p PodIdentity) IsService() bool {
-	return p.IdentityClass == IdentityClassService
-}
-
-func (p PodIdentity) IsExternal() bool {
-	return p.IdentityClass == IdentityClassExternal
-}
-
-func (p PodIdentity) IsUnresolved() bool {
-	return p.IdentityClass == IdentityClassUnresolved || p.IdentityClass == ""
-}
-
-func (p PodIdentity) NamespaceLabel() string {
-	switch p.IdentityClass {
-	case IdentityClassPod:
-		if p.Namespace == "" {
-			return "unknown"
-		}
-		return p.Namespace
-	case IdentityClassNode:
-		return "host"
-	case IdentityClassService:
-		if p.Namespace == "" {
-			return "service"
-		}
-		return p.Namespace
-	case IdentityClassExternal:
-		return "external"
-	case IdentityClassUnresolved:
-		return "unresolved"
-	default:
-		return "unknown"
-	}
-}
-
-func (p PodIdentity) WorkloadLabel() string {
-	switch p.IdentityClass {
-	case IdentityClassPod:
-		// Deployment/StatefulSet/DaemonSet 등 owner가 있으면 그 이름 사용
-		if p.Workload != "" {
-			name := normalizeWorkloadName(p.WorkloadKind, p.Workload)
-			if name != "" {
-				return name
-			}
-		}
-		// owner가 없으면 pod 이름이라도 남겨서 unknown 남발 방지
-		if p.PodName != "" {
-			return p.PodName
-		}
-		return "unknown"
-
-	case IdentityClassNode:
-		if p.NodeName != "" {
-			return "node/" + p.NodeName
-		}
-		return "host-network"
-
-	case IdentityClassService:
-		if p.Workload != "" {
-			return "svc/" + p.Workload
-		}
-		return "service"
-
-	case IdentityClassExternal:
-		return "external"
-
-	case IdentityClassUnresolved:
-		return "unresolved"
-
-	default:
-		return "unknown"
-	}
-}
-
-func normalizeWorkloadName(kind, name string) string {
-	if name == "" {
-		return ""
-	}
-
-	// StatefulSet 이름은 원래 안정적이므로 그대로 둔다.
-	if kind == "StatefulSet" {
-		return name
-	}
-
-	if trimmed := TrimGeneratedSuffix(name); trimmed != "" {
-		return trimmed
-	}
-	return name
-}
-
-func TrimGeneratedSuffix(name string) string {
-	parts := strings.Split(name, "-")
-	if len(parts) < 2 {
-		return ""
-	}
-
-	last := parts[len(parts)-1]
-	if !isHashLikeSuffix(last) {
-		return ""
-	}
-
-	return strings.Join(parts[:len(parts)-1], "-")
-}
-
-func isHashLikeSuffix(s string) bool {
-	if len(s) < 8 || len(s) > 16 {
-		return false
-	}
-
-	for _, ch := range s {
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func (p PodIdentity) NodeLabel() string {
-	if p.NodeName == "" {
-		return "unknown"
-	}
-	return p.NodeName
-}
-
-// namespace/pod 또는 node/노드명 또는 svc/서비스명 또는 IP 등 최대한 식별 가능한 형태로 표현
-func (p PodIdentity) String() string {
-	switch p.IdentityClass {
-	case IdentityClassPod:
-		if p.Namespace != "" && p.PodName != "" {
-			return fmt.Sprintf("%s/%s", p.Namespace, p.PodName)
-		}
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "pod"
-	case IdentityClassNode:
-		if p.NodeName != "" {
-			return "node/" + p.NodeName
-		}
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "host"
-	case IdentityClassService:
-		if p.Namespace != "" && p.Workload != "" {
-			return fmt.Sprintf("%s/svc/%s", p.Namespace, p.Workload)
-		}
-		if p.Workload != "" {
-			return "svc/" + p.Workload
-		}
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "service"
-	case IdentityClassExternal:
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "external"
-	case IdentityClassUnresolved:
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "unresolved"
-	default:
-		if p.PodIP != "" {
-			return p.PodIP
-		}
-		return "unknown"
-	}
-}
-
-func (p PodIdentity) Rank() int {
-	switch p.IdentityClass {
-	case IdentityClassPod:
-		return 5
-	case IdentityClassService:
-		return 4
-	case IdentityClassNode:
-		return 3
-	case IdentityClassExternal:
-		return 2
-	case IdentityClassUnresolved:
-		return 1
-	default:
-		return 0
-	}
-}
-
-func (p PodIdentity) WorkloadKey() string {
-	switch p.IdentityClass {
-	case IdentityClassPod:
-		kind := p.WorkloadKind
-		if kind == "" {
-			kind = "Pod"
-		}
-		return p.NamespaceLabel() + "/" + kind + "/" + p.WorkloadLabel()
-	case IdentityClassService:
-		return p.NamespaceLabel() + "/Service/" + p.WorkloadLabel()
-	case IdentityClassNode:
-		return "host/Node/" + p.WorkloadLabel()
-	case IdentityClassExternal:
-		return "external/External/external"
-	case IdentityClassUnresolved:
-		return "unresolved/Unresolved/unresolved"
-	default:
-		return "unknown/Unknown/unknown"
-	}
-}
-
-// --------------------- EnrichedEvent 관련 메서드 ---------------------
+// SourceNamespaceLabel/SourceWorkloadLabel은 Src PodIdentity 메서드를 메트릭 호출부에서
+// 짧게 쓰기 위한 위임자다.
 func (e EnrichedEvent) SourceNamespaceLabel() string {
 	return e.Src.NamespaceLabel()
 }
@@ -338,9 +99,9 @@ func CommString(comm [16]byte) string {
 	return string(comm[:n])
 }
 
-// BPF는 network byte order 바이트를 네이티브 엔디언 uint32로 기록한다.
-// Go에서도 동일하게 NativeEndian으로 바이트를 재구성하면
-// LE/BE 양쪽에서 항상 올바른 IP 문자열이 나온다.
+// U32ToIPv4는 BPF가 network byte order 바이트를 네이티브 엔디언 uint32로 기록한 값을
+// 사람이 읽을 수 있는 IPv4 문자열로 변환한다. NativeEndian으로 재구성하면 LE/BE 양쪽에서
+// 항상 올바른 결과가 나온다.
 func U32ToIPv4(v uint32) string {
 	var b [4]byte
 	binary.NativeEndian.PutUint32(b[:], v)


### PR DESCRIPTION
## Summary
- `PodIdentity`/`IdentityClass`/`TrimGeneratedSuffix` 등 식별 모델을 `internal/kube`로 승격해 netobs/gpuobs가 동일 어휘를 공유하도록 한다
- IP→PodIdentity informer 인덱스와 `ResolveIP`/`StrongerIdentity`/`WithObservedIP`를 `kube.Resolver`로 분리하고, netobs 전용 socket-cookie flow / cgroup·ifindex hint 캐시는 `metadata.Enricher`로 좁힌다
- `cmd/netobs-agent`는 `kube.NewResolver` + `metadata.NewEnricher` 두 단계 명시 DI로 변경되며, 외부 동작은 무변경이다 (Phase 3 #11 선행 작업)

## Commits
1. `refactor(kube): PodIdentity 및 helper를 internal/kube로 승격`
2. `refactor(kube): Resolver core를 internal/kube로 승격`
3. `refactor(netobs): metadata를 kube.Resolver wrapper(Enricher)로 재구조`
4. `test(kube): identity 및 resolver 단위 테스트 추가`

## Test plan
- [x] `go build ./...`
- [x] `go vet -all ./...`
- [x] `go test ./...` — kube 신규 테스트 26 case 포함 모두 통과
- [x] `gofmt -l` clean
- [x] 클러스터 smoke: netobs-agent /metrics와 /readyz가 머지 전과 동일한지 확인

Refs #18 
Closes #18 