### PR TITLE
feat(observability): Grafana 기본 dashboard 매니페스트 도입 (netobs / gpuobs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ CGO_netobs-agent := 0
 CGO_gpuobs-agent := 1
 
 # ============================================================================
-# Overlay registry — <agent-domain>-<rollout-stage> 형식
+# Overlay registry — 기본은 <agent-domain>-<rollout-stage> 형식이지만 dev/prod 분기가
+# 없는 클러스터 공용 패키지는 단일 이름 (예: dashboards) 으로 등록한다.
 # 새 overlay 추가 시:
 #   1) OVERLAYS에 이름 추가
 #   2) OVERLAY_PATH_<name>에 kustomize 경로 지정

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,15 @@ CGO_gpuobs-agent := 1
 #   2) OVERLAY_PATH_<name>에 kustomize 경로 지정
 # 이후 render-<name>, deploy-<name>, delete-<name>이 자동으로 매치된다.
 # ============================================================================
-OVERLAYS := netobs-dev netobs-prod gpuobs-dev gpuobs-prod
+OVERLAYS := netobs-dev netobs-prod gpuobs-dev gpuobs-prod dashboards
 
 OVERLAY_PATH_netobs-dev  := deploy/netobs/overlays/dev
 OVERLAY_PATH_netobs-prod := deploy/netobs/overlays/prod
 OVERLAY_PATH_gpuobs-dev  := deploy/gpuobs/overlays/dev
 OVERLAY_PATH_gpuobs-prod := deploy/gpuobs/overlays/prod
+# dashboards 는 dev/prod 분기가 없는 클러스터 공용 패키지다. Grafana sidecar 가 cluster 전체
+# ConfigMap 을 watch 하므로 단일 배포로 충분하다.
+OVERLAY_PATH_dashboards  := deploy/dashboards
 
 # ============================================================================
 # Architecture detection (BPF 컴파일용)

--- a/deploy/dashboards/gpuobs.json
+++ b/deploy/dashboards/gpuobs.json
@@ -46,7 +46,7 @@
         "name": "src_pod",
         "type": "query",
         "datasource": "${datasource}",
-        "query": "label_values(gpuobs_pod_memory_used_bytes{node=~\"$node\"}, src_pod)",
+        "query": "label_values(gpuobs_pod_memory_used_bytes{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}, src_pod)",
         "multi": true,
         "includeAll": true,
         "label": "Pod (GPU 워크로드)",
@@ -163,7 +163,7 @@
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
       "targets": [
         {
-          "expr": "gpuobs_pod_memory_used_bytes{node=~\"$node\",src_pod=~\"$src_pod\"}",
+          "expr": "gpuobs_pod_memory_used_bytes{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\",src_pod=~\"$src_pod\"}",
           "legendFormat": "{{src_namespace}}/{{src_pod}} gpu{{gpu_index}}",
           "refId": "A"
         }
@@ -179,7 +179,7 @@
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
       "targets": [
         {
-          "expr": "sum by (src_namespace, src_pod, gpu_uuid) (rate(gpuobs_cuda_kernel_launches_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
+          "expr": "sum by (src_namespace, src_pod, gpu_uuid) (rate(gpuobs_cuda_kernel_launches_total{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\",src_pod=~\"$src_pod\"}[5m]))",
           "legendFormat": "{{src_namespace}}/{{src_pod}} {{gpu_uuid}}",
           "refId": "A"
         }
@@ -195,13 +195,13 @@
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
       "targets": [
         {
-          "expr": "sum by (src_namespace, src_pod) (rate(gpuobs_cuda_h2d_bytes_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
-          "legendFormat": "H2D {{src_namespace}}/{{src_pod}}",
+          "expr": "sum by (src_namespace, src_pod, gpu_uuid) (rate(gpuobs_cuda_h2d_bytes_total{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\",src_pod=~\"$src_pod\"}[5m]))",
+          "legendFormat": "H2D {{src_namespace}}/{{src_pod}} {{gpu_uuid}}",
           "refId": "A"
         },
         {
-          "expr": "sum by (src_namespace, src_pod) (rate(gpuobs_cuda_d2h_bytes_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
-          "legendFormat": "D2H {{src_namespace}}/{{src_pod}}",
+          "expr": "sum by (src_namespace, src_pod, gpu_uuid) (rate(gpuobs_cuda_d2h_bytes_total{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\",src_pod=~\"$src_pod\"}[5m]))",
+          "legendFormat": "D2H {{src_namespace}}/{{src_pod}} {{gpu_uuid}}",
           "refId": "B"
         }
       ]

--- a/deploy/dashboards/gpuobs.json
+++ b/deploy/dashboards/gpuobs.json
@@ -1,0 +1,210 @@
+{
+  "title": "gpuobs",
+  "uid": "gpuobs-overview",
+  "tags": ["gpuobs", "ebpf", "nvml"],
+  "schemaVersion": 38,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 0,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "hide": 0,
+        "current": {},
+        "refresh": 1
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(gpuobs_device_utilization_percent, node)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Node",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "gpu_uuid",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(gpuobs_device_utilization_percent{node=~\"$node\"}, gpu_uuid)",
+        "multi": true,
+        "includeAll": true,
+        "label": "GPU UUID",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "src_pod",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(gpuobs_pod_memory_used_bytes{node=~\"$node\"}, src_pod)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Pod (GPU 워크로드)",
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "GPU utilization %",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "gpuobs_device_utilization_percent{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "{{node}} gpu{{gpu_index}} ({{gpu_model}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "GPU memory used / total",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "gpuobs_device_memory_used_bytes{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "used {{node}} gpu{{gpu_index}}",
+          "refId": "A"
+        },
+        {
+          "expr": "gpuobs_device_memory_total_bytes{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "total {{node}} gpu{{gpu_index}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Temperature (current vs threshold)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "celsius" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "gpuobs_device_temperature_celsius{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "current {{node}} gpu{{gpu_index}}",
+          "refId": "A"
+        },
+        {
+          "expr": "gpuobs_device_temperature_threshold_celsius{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "{{threshold}} {{node}} gpu{{gpu_index}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Power usage vs limit (W)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "watt" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "gpuobs_device_power_usage_watts{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "usage {{node}} gpu{{gpu_index}}",
+          "refId": "A"
+        },
+        {
+          "expr": "gpuobs_device_power_limit_watts{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"}",
+          "legendFormat": "limit {{node}} gpu{{gpu_index}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Throttle active reasons",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "transformations": [
+        { "id": "organize", "options": { "indexByName": { "node": 0, "gpu_index": 1, "reason": 2, "Value": 3 } } }
+      ],
+      "targets": [
+        {
+          "expr": "gpuobs_device_throttle_active{node=~\"$node\",gpu_uuid=~\"$gpu_uuid\"} == 1",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Per-pod GPU memory used",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "gpuobs_pod_memory_used_bytes{node=~\"$node\",src_pod=~\"$src_pod\"}",
+          "legendFormat": "{{src_namespace}}/{{src_pod}} gpu{{gpu_index}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "CUDA kernel launch rate by pod",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (src_namespace, src_pod, gpu_uuid) (rate(gpuobs_cuda_kernel_launches_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
+          "legendFormat": "{{src_namespace}}/{{src_pod}} {{gpu_uuid}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "CUDA H2D / D2H transfer bytes/s by pod",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (src_namespace, src_pod) (rate(gpuobs_cuda_h2d_bytes_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
+          "legendFormat": "H2D {{src_namespace}}/{{src_pod}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (src_namespace, src_pod) (rate(gpuobs_cuda_d2h_bytes_total{node=~\"$node\",src_pod=~\"$src_pod\"}[5m]))",
+          "legendFormat": "D2H {{src_namespace}}/{{src_pod}}",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/dashboards/kustomization.yaml
+++ b/deploy/dashboards/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 # 클러스터 전체 ConfigMap 을 감시한다. 본 패키지는 netobs / gpuobs 에이전트의 메트릭을 즉시
 # 시각화 가능한 두 dashboard 를 생성해 운영자가 별도 패널 작성 없이 진단을 시작하도록 한다.
 # 네임스페이스는 ebpf-project 로 두어 두 에이전트 매니페스트와 동일 위치에서 관리한다.
+# 본 패키지는 Namespace 리소스를 직접 생성하지 않으므로 단독 적용 시 ebpf-project Namespace
+# 가 사전에 존재해야 한다. 통상 netobs 또는 gpuobs 패키지 (deploy/netobs/base/namespace.yaml)
+# 가 먼저 배포된 클러스터에서 본 패키지를 적용하므로 별도 선행 작업이 필요한 경우는 드물다.
 namespace: ebpf-project
 
 # JSON 파일을 직접 임베드하는 configMapGenerator 패턴을 쓴다. dashboard JSON 변경 시

--- a/deploy/dashboards/kustomization.yaml
+++ b/deploy/dashboards/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Grafana sidecar (kiwigrid/k8s-sidecar) 가 NAMESPACE=ALL + LABEL=grafana_dashboard=1 조건으로
+# 클러스터 전체 ConfigMap 을 감시한다. 본 패키지는 netobs / gpuobs 에이전트의 메트릭을 즉시
+# 시각화 가능한 두 dashboard 를 생성해 운영자가 별도 패널 작성 없이 진단을 시작하도록 한다.
+# 네임스페이스는 ebpf-project 로 두어 두 에이전트 매니페스트와 동일 위치에서 관리한다.
+namespace: ebpf-project
+
+# JSON 파일을 직접 임베드하는 configMapGenerator 패턴을 쓴다. dashboard JSON 변경 시
+# kustomize 가 자동으로 ConfigMap data 를 재생성한다. disableNameSuffixHash=true 로 두어
+# 운영자가 항상 같은 이름 (netobs-dashboard / gpuobs-dashboard) 으로 ConfigMap 을 식별할
+# 수 있게 한다 (Grafana sidecar 는 hash 접미사가 붙어도 동작하지만, kubectl 진단 흐름에서
+# 안정된 이름이 더 편하다).
+configMapGenerator:
+  - name: netobs-dashboard
+    files:
+      - netobs.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: netobs-agent
+        app.kubernetes.io/component: grafana-dashboard
+        app.kubernetes.io/part-of: ebpf-project
+  - name: gpuobs-dashboard
+    files:
+      - gpuobs.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: gpuobs-agent
+        app.kubernetes.io/component: grafana-dashboard
+        app.kubernetes.io/part-of: ebpf-project
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/dashboards/netobs.json
+++ b/deploy/dashboards/netobs.json
@@ -35,7 +35,7 @@
         "name": "src_namespace",
         "type": "query",
         "datasource": "${datasource}",
-        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{node=~\"$node\"}, src_namespace)",
+        "query": "label_values(netobs_stage_latency_labeled_seconds_count{node=~\"$node\"}, src_namespace)",
         "multi": true,
         "includeAll": true,
         "label": "Source namespace",
@@ -47,6 +47,7 @@
         "type": "query",
         "datasource": "${datasource}",
         "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{node=~\"$node\",src_namespace=~\"$src_namespace\"}, src_pod)",
+        "description": "netobs-agent의 Pod metrics가 비활성(POD_METRICS_ENABLED=false)인 환경에서는 본 변수가 비게 된다. 그 경우 'Per-pod stage latency p95' 패널만 영향을 받고 stage / drop / retransmission 패널은 정상 동작한다.",
         "multi": true,
         "includeAll": true,
         "label": "Source pod",
@@ -65,7 +66,7 @@
       "fieldConfig": { "defaults": { "unit": "s" } },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\",src_namespace=~\"$src_namespace\"}[5m])))",
           "legendFormat": "{{stage}} ({{node}})",
           "refId": "A"
         }
@@ -80,7 +81,7 @@
       "fieldConfig": { "defaults": { "unit": "s" } },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\",src_namespace=~\"$src_namespace\"}[5m])))",
           "legendFormat": "{{stage}} ({{node}})",
           "refId": "A"
         }
@@ -96,7 +97,7 @@
       "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
       "targets": [
         {
-          "expr": "sum by (drop_category) (rate(netobs_drop_events_labeled_total{node=~\"$node\",src_namespace=~\"$src_namespace\",src_workload=~\".*\"}[5m]))",
+          "expr": "sum by (drop_category) (rate(netobs_drop_events_labeled_total{node=~\"$node\",src_namespace=~\"$src_namespace\"}[5m]))",
           "legendFormat": "{{drop_category}}",
           "refId": "A"
         }

--- a/deploy/dashboards/netobs.json
+++ b/deploy/dashboards/netobs.json
@@ -1,0 +1,156 @@
+{
+  "title": "netobs",
+  "uid": "netobs-overview",
+  "tags": ["netobs", "ebpf"],
+  "schemaVersion": 38,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 0,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "hide": 0,
+        "current": {},
+        "refresh": 1
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_stage_latency_labeled_seconds_count, node)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Node",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "src_namespace",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{node=~\"$node\"}, src_namespace)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Source namespace",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "src_pod",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{node=~\"$node\",src_namespace=~\"$src_namespace\"}, src_pod)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Source pod",
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Stage latency p99 by stage (filtered by node)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\"}[5m])))",
+          "legendFormat": "{{stage}} ({{node}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Stage latency p95 by stage (filtered by node)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, stage, node) (rate(netobs_stage_latency_labeled_seconds_bucket{node=~\"$node\"}[5m])))",
+          "legendFormat": "{{stage}} ({{node}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Drop rate by category (events/s)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (drop_category) (rate(netobs_drop_events_labeled_total{node=~\"$node\",src_namespace=~\"$src_namespace\",src_workload=~\".*\"}[5m]))",
+          "legendFormat": "{{drop_category}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Top drop reasons by workload (5m rate)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "transformations": [
+        { "id": "organize", "options": { "indexByName": { "Time": 0, "drop_reason": 1, "drop_category": 2, "src_namespace": 3, "src_workload": 4, "node": 5, "Value": 6 } } }
+      ],
+      "targets": [
+        {
+          "expr": "topk(20, sum by (drop_reason, drop_category, src_namespace, src_workload, node) (rate(netobs_drop_events_labeled_total{node=~\"$node\",src_namespace=~\"$src_namespace\"}[5m])))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "TCP retransmission rate by workload (events/s)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "sum by (node, src_namespace, src_workload) (rate(netobs_retrans_events_labeled_total{node=~\"$node\",src_namespace=~\"$src_namespace\"}[5m]))",
+          "legendFormat": "{{src_namespace}}/{{src_workload}} ({{node}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Per-pod stage latency p95 (filtered by src_pod)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, stage, src_pod, src_namespace) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{node=~\"$node\",src_namespace=~\"$src_namespace\",src_pod=~\"$src_pod\"}[5m])))",
+          "legendFormat": "{{src_namespace}}/{{src_pod}} {{stage}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
netobs와 gpuobs의 Prometheus 메트릭을 운영자가 매니페스트 / 코드 없이 즉시 시각화할 수 있도록 두 dashboard 매니페스트를 신설한다. kube-prometheus-stack Grafana의 sidecar (kiwigrid/k8s-sidecar) 가 NAMESPACE=ALL과 LABEL=grafana_dashboard=1 조건으로 ConfigMap을 watch 하는 환경에서 본 dashboard들이 자동 픽업된다.

## 변경 내역
1. `feat(observability)` `deploy/dashboards/` 패키지를 신설해 netobs.json, gpuobs.json, kustomization.yaml을 추가한다. `configMapGenerator` 와 `disableNameSuffixHash: true` 로 안정된 ConfigMap 이름 (`netobs-dashboard`, `gpuobs-dashboard`) 을 보장하고 sidecar 가 인식하는 label 셋을 자동 부여한다.
2. `feat(makefile)` Makefile의 OVERLAYS 리스트에 `dashboards` 를 추가한다. pattern rule이 자동 매치되어 `make render-dashboards`, `make deploy-dashboards`, `make delete-dashboards` 가 즉시 작동한다. dashboards는 dev/prod 분기 없는 클러스터 공용 패키지로 단일 배포 경로만 둔다.

## Dashboard 구성
| Dashboard | UID | Panel 수 | 주요 패널 |
|---|---|---|---|
| netobs (`netobs-overview`) | netobs-overview | 6 | stage latency p99/p95, drop rate by category, top drop reasons table, TCP retransmission rate by workload, per-pod stage latency p95 |
| gpuobs (`gpuobs-overview`) | gpuobs-overview | 8 | GPU utilization, memory used/total, temperature vs threshold, power usage vs limit, throttle active reasons table, per-pod GPU memory, CUDA kernel launch rate, CUDA H2D/D2H transfer bytes |

두 dashboard 모두 `datasource` (Prometheus 선택), `node` (multi-select), `src_pod` (multi-select) 변수를 dropdown 으로 노출한다. netobs는 추가로 `src_namespace`, gpuobs는 추가로 `gpu_uuid` 변수를 가진다. 변수는 cascading 으로 동작해 노드 선택이 namespace / pod 후보를 좁힌다.

## 검증
| 단계 | 결과 |
|---|---|
| JSON 문법 검증 | 두 파일 모두 OK |
| kustomize build | ConfigMap 2건 정상 생성, label 셋 매핑 확인 |
| 통합 테스트 T1~T6 | 5.594s 전체 통과 |
| `make deploy-dashboards` | ConfigMap 2건 클러스터 적용 완료 |
| Grafana sidecar 픽업 | `/tmp/dashboards/netobs.json` 과 `/tmp/dashboards/gpuobs.json` 양쪽 write 로그 확인 |
| Grafana file provisioner 로드 | `/api/search?query=netobs` 와 `/api/search?query=gpuobs` 양쪽 응답에서 dashboard 검색됨. UID 정확히 매칭 |
| panel 수 와 variable 셋 | API `/api/dashboards/uid/...` 응답으로 netobs 6 panel + 4 variable, gpuobs 8 panel + 4 variable 일치 확인 |

## 한계와 follow-up
- gpuobs dashboard의 per-pod GPU memory와 CUDA 관련 3개 패널은 활성 GPU 워크로드가 없으면 "No data" 로 표시된다. 메트릭 emit 경로가 조건부 (Pod metrics enabled + 워크로드가 NVML에 등장) 이기 때문이며 운영상 정상 동작이다.
- 클러스터 통합 overview dashboard (3 layer drill-down, alert annotation 통합, 이상 자동 하이라이트) 는 별도 이슈 #53 에서 다룬다.

## Closes
Closes #45
