### PR TITLE
feat(correlation): 시계열 수집과 피어슨 상관계수 스코어링 패키지 도입

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ BPF_CFLAGS := -O2 -g -D__TARGET_ARCH_$(TARGET_ARCH)
 .PHONY: deps generate generate-gpuobs clean tree bump \
 	build-all image-build-all image-push-all \
 	test test-integration setup-envtest \
-	check-prometheus-rules
+	check-prometheus-rules \
+	build-correlation-debug
 
 # ============================================================================
 # Tests
@@ -179,6 +180,18 @@ image-build-%-agent: $$(PREREQS_$$*-agent)
 image-push-%-agent: image-build-%-agent
 	docker tag $*-agent:$(VERSION) $(REGISTRY_BASE)/$*-agent:$(VERSION)
 	docker push $(REGISTRY_BASE)/$*-agent:$(VERSION)
+
+# ============================================================================
+# correlation-debug CLI
+# ----------------------------------------------------------------------------
+# build-correlation-debug - internal/correlation 라이브러리의 일회성 검증 CLI 를 빌드한다.
+#                           DaemonSet / Deployment 형태로 cluster 에 배포되지 않으며 운영자가 로컬
+#                           에서 build / 실행 (kubectl port-forward 로 Prometheus 접근) 한다.
+#                           주기적 자동화 exporter 는 #51 이 다룬다.
+# ============================================================================
+build-correlation-debug:
+	go fmt ./cmd/correlation-debug ./internal/correlation
+	go build -o ./bin/correlation-debug ./cmd/correlation-debug
 
 # 우산 타깃. AGENTS 리스트를 순회해 모든 에이전트에 동일 작업을 일괄 수행한다.
 build-all:       $(addprefix build-,$(AGENTS))

--- a/cmd/correlation-debug/main.go
+++ b/cmd/correlation-debug/main.go
@@ -120,7 +120,9 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.FetchTimeout*time.Duration(len(cfg.DefaultMetrics)+len(cfg.ExtraMetrics)+1))
 	defer cancel()
 
-	results, err := corr.Correlate(ctx)
+	// CLI 는 \"지금 기준 직전 Window\" 가 자연스러운 의도라 time.Now() 를 명시 인자로 넘긴다. 과거
+// 시점 분석이 필요하면 운영자가 라이브러리를 직접 호출하거나 본 CLI 를 future fork 로 확장한다.
+	results, err := corr.Correlate(ctx, time.Now())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "correlation failed: %v\n", err)
 		os.Exit(exitFetchFailure)

--- a/cmd/correlation-debug/main.go
+++ b/cmd/correlation-debug/main.go
@@ -97,6 +97,18 @@ func main() {
 		fmt.Fprintln(os.Stderr, "window and step must be positive")
 		os.Exit(exitFlagError)
 	}
+	if cfg.FetchTimeout <= 0 {
+		fmt.Fprintln(os.Stderr, "fetch-timeout must be positive (zero or negative yields immediate context expiry)")
+		os.Exit(exitFlagError)
+	}
+	if cfg.MinSamples <= 0 {
+		fmt.Fprintln(os.Stderr, "min-samples must be positive")
+		os.Exit(exitFlagError)
+	}
+	if len(cfg.LagSteps) == 0 {
+		fmt.Fprintln(os.Stderr, "lag-steps must not be empty (at least one lag step required)")
+		os.Exit(exitFlagError)
+	}
 
 	fetcher := correlation.NewPrometheusFetcher(cfg.PrometheusURL, cfg.FetchTimeout)
 	corr := correlation.New(fetcher, cfg)

--- a/cmd/correlation-debug/main.go
+++ b/cmd/correlation-debug/main.go
@@ -1,0 +1,124 @@
+// correlation-debug 는 internal/correlation 라이브러리의 일회성 검증 CLI 다. 운영자가 GPU 유휴
+// alert 발화 후 직전 1시간 윈도우로 어떤 Pod 페어가 강한 상관을 보이는지 확인하는 흐름에 쓰인다.
+// 본 binary 는 cluster 에 배포되지 않으며 운영자가 로컬에서 build / 실행 (port-forward Prometheus
+// 접근) 한다. 주기적 자동화는 #51 (Top-N noisy neighbor exporter) 가 다룬다.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"netobs/internal/correlation"
+)
+
+// stringSlice 는 -extra-metric 처럼 반복 가능한 flag 를 위한 flag.Value 구현이다.
+type stringSlice []string
+
+func (s *stringSlice) String() string     { return strings.Join(*s, ",") }
+func (s *stringSlice) Set(v string) error { *s = append(*s, v); return nil }
+
+// intSlice 는 -lag-steps 처럼 콤마 구분 int 슬라이스를 받는 flag.Value 구현이다.
+type intSlice []int
+
+func (s *intSlice) String() string {
+	parts := make([]string, len(*s))
+	for i, v := range *s {
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (s *intSlice) Set(v string) error {
+	*s = (*s)[:0]
+	for _, tok := range strings.Split(v, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		n, err := strconv.Atoi(tok)
+		if err != nil {
+			return fmt.Errorf("invalid int in lag-steps %q: %w", tok, err)
+		}
+		*s = append(*s, n)
+	}
+	return nil
+}
+
+const (
+	exitOK            = 0
+	exitFetchFailure  = 1
+	exitFlagError     = 2
+	exitEncodeFailure = 3
+)
+
+func main() {
+	cfg := correlation.DefaultConfig()
+
+	// PROMETHEUS_URL env fallback 으로 default 보다 환경 변수가 우선하고 CLI flag 가 최우선.
+	if v := strings.TrimSpace(os.Getenv("PROMETHEUS_URL")); v != "" {
+		cfg.PrometheusURL = v
+	}
+
+	fs := flag.NewFlagSet("correlation-debug", flag.ContinueOnError)
+	fs.StringVar(&cfg.PrometheusURL, "prometheus-url", cfg.PrometheusURL, "Prometheus base URL (env PROMETHEUS_URL fallback)")
+	fs.DurationVar(&cfg.Window, "window", cfg.Window, "query_range window (e.g., 1h, 24h)")
+	fs.DurationVar(&cfg.Step, "step", cfg.Step, "query_range step (matches Prometheus scrape interval typically)")
+	fs.IntVar(&cfg.MinSamples, "min-samples", cfg.MinSamples, "minimum valid samples per pair after NaN/Inf removal; below threshold pairs are skipped")
+	fs.DurationVar(&cfg.FetchTimeout, "fetch-timeout", cfg.FetchTimeout, "HTTP timeout for each query_range call")
+
+	var extra stringSlice
+	fs.Var(&extra, "extra-metric", "additional Prometheus query to include (repeat for multiple)")
+
+	var lagSteps intSlice
+	for _, l := range cfg.LagSteps {
+		lagSteps = append(lagSteps, l)
+	}
+	fs.Var(&lagSteps, "lag-steps", "comma-separated lag steps (e.g., -1,0,1); a positive lag k means corr(a[t], b[t+k])")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(exitOK)
+		}
+		fmt.Fprintf(os.Stderr, "flag error: %v\n", err)
+		os.Exit(exitFlagError)
+	}
+	cfg.ExtraMetrics = []string(extra)
+	cfg.LagSteps = []int(lagSteps)
+
+	if cfg.Window <= 0 || cfg.Step <= 0 {
+		fmt.Fprintln(os.Stderr, "window and step must be positive")
+		os.Exit(exitFlagError)
+	}
+
+	fetcher := correlation.NewPrometheusFetcher(cfg.PrometheusURL, cfg.FetchTimeout)
+	corr := correlation.New(fetcher, cfg)
+
+	log.Printf("correlating: prometheus=%s window=%s step=%s lag_steps=%v min_samples=%d",
+		cfg.PrometheusURL, cfg.Window, cfg.Step, cfg.LagSteps, cfg.MinSamples)
+	log.Printf("metrics: default=%d extra=%d", len(cfg.DefaultMetrics), len(cfg.ExtraMetrics))
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.FetchTimeout*time.Duration(len(cfg.DefaultMetrics)+len(cfg.ExtraMetrics)+1))
+	defer cancel()
+
+	results, err := corr.Correlate(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "correlation failed: %v\n", err)
+		os.Exit(exitFetchFailure)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		fmt.Fprintf(os.Stderr, "json encode failed: %v\n", err)
+		os.Exit(exitEncodeFailure)
+	}
+	log.Printf("emitted %d correlation results", len(results))
+}

--- a/cmd/correlation-debug/main.go
+++ b/cmd/correlation-debug/main.go
@@ -125,7 +125,7 @@ func main() {
 	defer cancel()
 
 	// CLI 는 \"지금 기준 직전 Window\" 가 자연스러운 의도라 time.Now() 를 명시 인자로 넘긴다. 과거
-// 시점 분석이 필요하면 운영자가 라이브러리를 직접 호출하거나 본 CLI 를 future fork 로 확장한다.
+	// 시점 분석이 필요하면 운영자가 라이브러리를 직접 호출하거나 본 CLI 를 future fork 로 확장한다.
 	results, err := corr.Correlate(ctx, time.Now())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "correlation failed: %v\n", err)

--- a/cmd/correlation-debug/main.go
+++ b/cmd/correlation-debug/main.go
@@ -110,7 +110,11 @@ func main() {
 		os.Exit(exitFlagError)
 	}
 
-	fetcher := correlation.NewPrometheusFetcher(cfg.PrometheusURL, cfg.FetchTimeout)
+	fetcher, err := correlation.NewPrometheusFetcher(cfg.PrometheusURL, cfg.FetchTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize fetcher: %v\n", err)
+		os.Exit(exitFlagError)
+	}
 	corr := correlation.New(fetcher, cfg)
 
 	log.Printf("correlating: prometheus=%s window=%s step=%s lag_steps=%v min_samples=%d",

--- a/internal/correlation/README.md
+++ b/internal/correlation/README.md
@@ -15,13 +15,15 @@
 
 ## 기본 입력 메트릭
 
-`DefaultConfig`가 zero-config 호출에서 사용하는 11개 query는 다음과 같다. 본 시리즈의 #47 / #48 / #49에서 도입된 recording rule을 직접 참조한다.
+`DefaultConfig`가 zero-config 호출에서 사용하는 7개 query는 다음과 같다. 본 시리즈의 #47 / #48 / #49에서 도입된 recording rule을 직접 참조하며 모두 (node, src_namespace, src_pod, src_pod_uid) 라벨을 보유해 EnumeratePairs 의 Pod 페어 schema 와 정합한다.
 
-- pod 단위 cause score 6종: `pod:cpu_throttle_score:5m`, `pod:memory_pressure_score:5m`, `pod:network_throughput_score:5m`, `pod:network_retrans_score:5m`, `pod:host_compute_stall_score:5m`, `pod:gpu_memory_utilization_ratio:5m`
-- pod 단위 latency: `histogram_quantile(0.99, sum by(...)(rate(netobs_pod_stage_latency_labeled_seconds_bucket[5m])))`
-- node 단위 자원 4종: `node:gpu_idle:5m`, `node:gpu_pcie_saturation_score:5m`, `node:gpu_util_p95:5m`, `node:gpu_throttle_seconds:rate5m`
+- pod 단위 cause score 5종: `pod:cpu_throttle_score:5m`, `pod:memory_pressure_score:5m`, `pod:network_throughput_score:5m`, `pod:network_retrans_score:5m`, `pod:host_compute_stall_score:5m`
+- pod 단위 GPU 메모리 비율 (gpu_uuid / gpu_index 라벨을 pod 단위로 집계해 normalize): `avg by(node, src_namespace, src_pod, src_pod_uid) (pod:gpu_memory_utilization_ratio:5m)`
+- pod 단위 latency p99: `histogram_quantile(0.99, sum by(node, src_namespace, src_pod, src_pod_uid, le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket[5m])))`
 
-운영자는 `-extra-metric` flag로 추가 query를 등록 가능하다. 본 11종이 cluster의 PrometheusRule (`deploy/gpuobs/base/prometheus-rule.yaml`) 에 deploy되어 있어야 fetcher가 데이터를 받는다.
+node-level 메트릭 (`node:gpu_idle:5m` 등) 은 namespace / pod 라벨이 없어 본 패키지의 Pod 페어 schema 와 불일치라 default 에서 제외된다. 운영자가 명시적으로 node × pod 분석이 필요하면 별도 도구 또는 future cross-level schema (follow-up) 를 사용한다.
+
+운영자는 `-extra-metric` flag로 추가 query를 등록 가능하다. 본 7종이 cluster의 PrometheusRule (`deploy/gpuobs/base/prometheus-rule.yaml`) 에 deploy되어 있어야 fetcher가 데이터를 받는다.
 
 ## CLI 사용
 

--- a/internal/correlation/README.md
+++ b/internal/correlation/README.md
@@ -92,7 +92,7 @@ CLI는 `[]CorrelationResult`를 indented JSON으로 stdout에 emit한다. 각 el
 
 필드 의미는 다음과 같다.
 
-- `pair`: 페어 정체성 6필드 (`src_namespace`, `src_pod`, `src_metric`, `dst_namespace`, `dst_pod`, `dst_metric`)
+- `pair`: 페어 정체성 8필드 (`src_namespace`, `src_pod`, `src_pod_uid`, `src_metric`, `dst_namespace`, `dst_pod`, `dst_pod_uid`, `dst_metric`). `src_pod_uid` / `dst_pod_uid` 는 입력 recording rule 이 본 라벨을 보존할 때만 채워진다. 본 시리즈 #49 의 cause score 는 cAdvisor `pod` / `namespace` 라벨에서 alias 만 만들어 UID 가 없으니 빈 문자열로 emit 된다. UID 보강은 별도 PrometheusRule 작업으로 분리
 - `correlation_by_lag`: lag step별 Pearson 산출값 (-1 에서 1 사이)
 - `max_abs_lag`: 최대 절대값을 보인 lag step
 - `max_abs_value`: 최대 절대값 그 자체 (운영자가 "강한 상관"으로 거를 때 쓰는 일차 지표)

--- a/internal/correlation/README.md
+++ b/internal/correlation/README.md
@@ -1,18 +1,148 @@
 # internal/correlation
 
-이 패키지는 netobs와 gpuobs가 각각 발행하는 Prometheus 지표를 같은 조인 키(`node`, `src_namespace`, `src_pod`, `src_pod_uid`)로 묶어 네트워크 병목과 GPU 병목을 한 차원에서 함께 분석할 수 있도록 하기 위한 자리이다. 현재는 의도적으로 비어 있으며, 아래 착수 조건이 모두 충족된 뒤에 별도 이슈에서 구현을 시작한다.
+본 패키지는 Prometheus query_range API로 가져온 netobs와 gpuobs 시계열의 Pearson 상관계수를 산출하는 stateless 라이브러리다. 데이터 수집 파이프라인 (DaemonSet agent → Prometheus scrape → TSDB) 과 분리된 후행 분석 layer로 동작하며 운영자가 `cmd/correlation-debug` CLI로 1회성 호출하는 형태가 이슈 #50의 expose 범위다. 주기적 자동화 (exporter / CronJob) 는 #51에서 다룬다.
 
-## 착수 조건
+## 책임
 
-- [ ] gpuobs Phase 3이 완료되어 `gpuobs_pod_*` 지표가 안정적으로 발행됨
-- [ ] `netobs_pod_stage_*`와 `gpuobs_pod_*`의 라벨 키 집합이 확정되어 추후 변경 부담이 낮음
-- [ ] Grafana/PromQL에서 두 지표 집합을 실제로 join하는 샘플 쿼리 검증
+본 패키지가 다루는 책임은 다음 네 가지다.
 
-## 관련 이슈
+- Prometheus `/api/v1/query_range`로 다중 메트릭의 시계열을 가져오기 (`fetcher.go`)
+- 노드 내 Pod 페어를 enumerate해 cross-product 폭발을 통제 (`pair.go`)
+- 각 페어의 Pearson 상관계수를 lag 0 / +1 / -1 세 시점에서 산출 후 최대 절대값 채택 (`pearson.go`)
+- 결과를 `CorrelationResult` slice로 반환 (`correlator.go`)
 
-- 상위 설계 이슈 #7 (GPU 관측 에이전트 분리 도입 설계)
-- 후속 구현 이슈 `feat(correlation): netobs × gpuobs 조인 지표 도입` (착수 조건 충족 후 별도로 open)
+모든 산출은 호출 단위 stateless다. 시계열 buffer는 함수 scope 내 임시 자료로만 존재하고 GC된다. 영구 저장소를 두지 않으며 cluster에 새 워크로드를 추가하지 않는다.
 
-## 현재 상태
+## 기본 입력 메트릭
 
-`doc.go` 한 개 파일만 존재하며 공개 API는 없다. 다른 어떤 패키지에서도 import되지 않으며, 착수 시점에 이 디렉토리가 구현의 홈이 된다.
+`DefaultConfig`가 zero-config 호출에서 사용하는 11개 query는 다음과 같다. 본 시리즈의 #47 / #48 / #49에서 도입된 recording rule을 직접 참조한다.
+
+- pod 단위 cause score 6종: `pod:cpu_throttle_score:5m`, `pod:memory_pressure_score:5m`, `pod:network_throughput_score:5m`, `pod:network_retrans_score:5m`, `pod:host_compute_stall_score:5m`, `pod:gpu_memory_utilization_ratio:5m`
+- pod 단위 latency: `histogram_quantile(0.99, sum by(...)(rate(netobs_pod_stage_latency_labeled_seconds_bucket[5m])))`
+- node 단위 자원 4종: `node:gpu_idle:5m`, `node:gpu_pcie_saturation_score:5m`, `node:gpu_util_p95:5m`, `node:gpu_throttle_seconds:rate5m`
+
+운영자는 `-extra-metric` flag로 추가 query를 등록 가능하다. 본 11종이 cluster의 PrometheusRule (`deploy/gpuobs/base/prometheus-rule.yaml`) 에 deploy되어 있어야 fetcher가 데이터를 받는다.
+
+## CLI 사용
+
+### 빌드
+
+```sh
+make build-correlation-debug
+```
+
+산출물은 `./bin/correlation-debug`다.
+
+### Prometheus 접근 준비
+
+cluster 외부에서 실행하려면 Prometheus 서비스에 접근 경로가 필요하다. 두 가지 방법 중 하나를 사용한다.
+
+- 포트 포워딩: `kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090`
+- ClusterIP 직접 접근 (운영자가 cluster 네트워크에서 실행 시): Prometheus svc IP를 `-prometheus-url`로 전달
+
+### 실행 예시
+
+```sh
+# 직전 1시간 윈도우 산출
+./bin/correlation-debug -prometheus-url http://localhost:9090 -window 1h
+
+# 24시간 윈도우 + 추가 metric 등록
+./bin/correlation-debug \
+  -prometheus-url http://localhost:9090 \
+  -window 24h \
+  -min-samples 60 \
+  -extra-metric 'rate(container_cpu_usage_seconds_total[5m])'
+
+# Top-N 강한 상관 추출 (jq 후처리)
+./bin/correlation-debug -window 1h | \
+  jq '[.[] | select(.status == "ok")] | sort_by(-.max_abs_value) | .[:10]'
+```
+
+### 환경 변수
+
+`PROMETHEUS_URL` env가 `-prometheus-url` flag보다 우선순위 낮은 default로 적용된다.
+
+## 출력 schema
+
+CLI는 `[]CorrelationResult`를 indented JSON으로 stdout에 emit한다. 각 element 구조는 다음과 같다.
+
+```json
+{
+  "pair": {
+    "src_namespace": "gpu-monitoring",
+    "src_pod": "dcgm-dcgm-exporter-85bp8",
+    "src_metric": "pod:cpu_throttle_score:5m",
+    "dst_namespace": "ebpf-project",
+    "dst_pod": "netobs-agent-5trsf",
+    "dst_metric": "pod:memory_pressure_score:5m"
+  },
+  "correlation_by_lag": {
+    "-1": -0.0962,
+    "0":  -0.1598,
+    "1":  -0.1808
+  },
+  "max_abs_lag": 1,
+  "max_abs_value": 0.1808,
+  "sample_count": 121,
+  "status": "ok"
+}
+```
+
+필드 의미는 다음과 같다.
+
+- `pair`: 페어 정체성 6필드 (`src_namespace`, `src_pod`, `src_metric`, `dst_namespace`, `dst_pod`, `dst_metric`)
+- `correlation_by_lag`: lag step별 Pearson 산출값 (-1 에서 1 사이)
+- `max_abs_lag`: 최대 절대값을 보인 lag step
+- `max_abs_value`: 최대 절대값 그 자체 (운영자가 "강한 상관"으로 거를 때 쓰는 일차 지표)
+- `sample_count`: NaN/Inf pairwise 제거 후 유효 표본 수
+- `status`: 산출 분류 (`ok` / `partial` / `skipped_low_samples` / `skipped_constant`)
+
+`status`별 의미는 `types.go`의 const 주석을 참고한다.
+
+## 정책
+
+본 라이브러리가 고정한 정책은 다음과 같다.
+
+- **lag 의미**: cross-correlation 관례를 따라 lag k가 양수면 `corr(a[t], b[t+k])`를 계산 (a가 b를 k step 앞서는 propagation)
+- **pair enumeration**: 동일 node 라벨 + self 제외 + (X,Y) (Y,X) 양방향. cross-node pair는 본 패키지 범위 밖
+- **NaN/Inf 처리**: pairwise 제거 후 산출. NaN이 결과로 새 나가지 않게 가드
+- **length mismatch**: 짧은 쪽 기준 truncate
+- **분산 0 (상수 시계열)**: `0.0`과 `StatusSkippedConstant` 반환. Pearson 정의상 분모 0이 되는 NaN을 명시적 fallback
+- **표본 부족**: `MinSamples` 미만이면 `StatusSkippedLowSamples`. default 60 (1h / 30s 윈도우의 절반 이상)
+
+## 실 클러스터 24h 검증 결과
+
+본 PR 검증 시점 (dev cluster) 의 24시간 윈도우 산출 결과는 다음과 같다.
+
+- 총 산출 페어: 808
+- `status=ok`: 672건
+- `status=skipped_constant`: 136건 (트래픽 없는 dev 상태의 일부 score가 sustained 0)
+- NaN 출현: **0건** (수용 조건 충족)
+- `|max_abs_value| > 1`: **0건** (수용 조건 충족)
+- `max_abs_value` 최대: 0.7584
+- `max_abs_value` 중앙값: 0.0396
+
+수용 조건 "실 클러스터의 24h 데이터로 호출되어 합리적 (NaN 없음, 절대값 1 이하) score를 반환" 충족.
+
+## 합성 시나리오 cross-validation
+
+`#49` docs의 합성 시나리오 (CPU stress, iperf3 네트워크 부하) 와 본 패키지 산출 결과의 일치성 검증은 다음 절차로 수행한다.
+
+- dev cluster에 stress-ng / iperf3 workload Pod을 5분 이상 가동
+- `kubectl port-forward`로 Prometheus 접근
+- `./bin/correlation-debug -window 10m -min-samples 10` 실행
+- 결과에서 부하 Pod의 `pod:cpu_throttle_score:5m` 또는 `pod:network_throughput_score:5m`과 인접 Pod의 latency 사이 `max_abs_value`가 0.5 이상으로 잡히는지 확인
+
+본 절차는 `#52` (injector) 머지 후 자동화로 흡수 예정이다.
+
+## limitations
+
+- **lag 범위**: 기본 ±1 step (30s)만 산출. 더 긴 propagation delay는 `-lag-steps` flag로 확장 (예: `-3,-2,-1,0,1,2,3`)
+- **same-node 한정**: cross-node pair는 분석 의미가 모호하고 cardinality 위험이 커 본 PR에서 제외. 별도 follow-up에서 다룸
+- **N^2 cost**: 노드당 Pod 수가 많을수록 페어 수가 2차 증가. 50 Pod 노드에서 50 × 50 × 11 metric × 3 lag = 약 82k 산출. 1회성 CLI 실행은 수 초 내 완료되나 exporter 주기 실행 시 부담
+- **Prometheus 인증**: kube-prometheus-stack default unauth in-cluster 가정. mTLS / OIDC 환경은 reverse proxy로 우회 필요
+- **단순 max 결합**: `pod:host_compute_stall_score:5m`의 max 결합 한계는 `#49`와 동일하게 follow-up에서 정밀화
+
+## `#51` exporter 연계
+
+본 CLI의 stdout JSON schema (`CorrelationResult`) 는 `#51` (Top-N noisy neighbor exporter) 의 입력으로 재사용된다. struct의 `json` tag가 명시적으로 부여되어 schema가 동결되어 있다. exporter는 본 패키지를 라이브러리로 import해 주기적 `Correlate(ctx)` 호출 후 결과를 Prometheus 메트릭으로 변환하는 형태를 따른다.

--- a/internal/correlation/config.go
+++ b/internal/correlation/config.go
@@ -48,20 +48,19 @@ func DefaultConfig() Config {
 		MinSamples:    60,
 		LagSteps:      []int{-1, 0, 1},
 		DefaultMetrics: []string{
-			// #49 의 pod 단위 cause score 6종.
+			// #49 의 pod 단위 cause score 6종. 모두 (node, src_namespace, src_pod, src_pod_uid) 라벨을
+			// 보유해 EnumeratePairs 의 pod 페어 schema 와 정합한다.
 			"pod:cpu_throttle_score:5m",
 			"pod:memory_pressure_score:5m",
 			"pod:network_throughput_score:5m",
 			"pod:network_retrans_score:5m",
 			"pod:host_compute_stall_score:5m",
-			"pod:gpu_memory_utilization_ratio:5m",
+			// pod:gpu_memory_utilization_ratio:5m 은 gpu_uuid / gpu_index 라벨을 추가로 보유해
+			// multi-GPU pod 에서 동일 (namespace, pod) 에 여러 series 가 생성되어 PairKey 중복이 발생
+			// 한다. avg by(...) 로 pod 단위 집계해 단일 series 로 normalize 한다.
+			`avg by(node, src_namespace, src_pod, src_pod_uid) (pod:gpu_memory_utilization_ratio:5m)`,
 			// netobs 의 pod-level latency p99.
 			`histogram_quantile(0.99, sum by(node, src_namespace, src_pod, src_pod_uid, le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket[5m])))`,
-			// node 단위 자원.
-			"node:gpu_idle:5m",
-			"node:gpu_pcie_saturation_score:5m",
-			"node:gpu_util_p95:5m",
-			"node:gpu_throttle_seconds:rate5m",
 		},
 		FetchTimeout: 30 * time.Second,
 	}

--- a/internal/correlation/config.go
+++ b/internal/correlation/config.go
@@ -1,0 +1,68 @@
+package correlation
+
+import "time"
+
+// Config 는 Correlator 가 산출에 사용하는 모든 운영 파라미터를 모은다. zero-config 운영을 위해
+// DefaultConfig 가 본 시리즈 (#47 / #48 / #49) 에서 도입된 메트릭들을 default DefaultMetrics 로
+// 채워둔다.
+type Config struct {
+	// PrometheusURL 은 query_range API 의 base URL 이다 (예: http://localhost:9090). PrometheusFetcher
+	// 가 본 URL 에 /api/v1/query_range 를 붙여 호출한다.
+	PrometheusURL string
+
+	// Window 는 query_range 의 시간 범위다. end = now, start = now - Window 가 적용된다.
+	Window time.Duration
+
+	// Step 은 query_range 의 step 이다. window / step 이 표본 수의 최대치다. Prometheus scrape
+	// interval (보통 30s) 과 일치시키는 게 자연스럽다.
+	Step time.Duration
+
+	// MinSamples 는 Pearson 산출에 요구되는 최소 유효 표본 수다. NaN / Inf pairwise 제거 후의 수가
+	// 본 값 미만이면 산출이 skip 된다.
+	MinSamples int
+
+	// LagSteps 는 PearsonWithLag 가 산출할 lag step 들이다. 0 은 동시점, +N 은 a 가 b 를 N step
+	// 앞서는 관계, -N 은 b 가 a 를 앞서는 관계다. step 의 시간 의미는 Step 과 곱해서 산출된다.
+	LagSteps []int
+
+	// DefaultMetrics 는 zero-config 산출 대상 query 들이다. #49 의 cause score 와 latency 가 기본
+	// 으로 들어가 운영자가 환경 변수 없이 CLI 만 실행하면 GPU 유휴 진단에 즉시 활용 가능하다.
+	DefaultMetrics []string
+
+	// ExtraMetrics 는 운영자가 추가한 query 들이다. DefaultMetrics 에 합쳐져 모든 query 가 동일
+	// start / end / step 으로 fetch 된다.
+	ExtraMetrics []string
+
+	// FetchTimeout 은 단일 query_range 호출의 HTTP timeout 이다. 24h 윈도우 큰 응답을 받을 때 default
+	// 너무 짧으면 timeout 위험이 있어 30s 이상을 권장한다.
+	FetchTimeout time.Duration
+}
+
+// DefaultConfig 는 운영자가 zero-config 로 본 라이브러리를 호출할 때 쓰이는 default Config 다.
+// DefaultMetrics 는 본 시리즈에서 이미 deploy 된 PrometheusRule recording rule 명을 직접 참조한다.
+func DefaultConfig() Config {
+	return Config{
+		PrometheusURL: "http://localhost:9090",
+		Window:        1 * time.Hour,
+		Step:          30 * time.Second,
+		MinSamples:    60,
+		LagSteps:      []int{-1, 0, 1},
+		DefaultMetrics: []string{
+			// #49 의 pod 단위 cause score 6종.
+			"pod:cpu_throttle_score:5m",
+			"pod:memory_pressure_score:5m",
+			"pod:network_throughput_score:5m",
+			"pod:network_retrans_score:5m",
+			"pod:host_compute_stall_score:5m",
+			"pod:gpu_memory_utilization_ratio:5m",
+			// netobs 의 pod-level latency p99.
+			`histogram_quantile(0.99, sum by(node, src_namespace, src_pod, src_pod_uid, le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket[5m])))`,
+			// node 단위 자원.
+			"node:gpu_idle:5m",
+			"node:gpu_pcie_saturation_score:5m",
+			"node:gpu_util_p95:5m",
+			"node:gpu_throttle_seconds:rate5m",
+		},
+		FetchTimeout: 30 * time.Second,
+	}
+}

--- a/internal/correlation/correlator.go
+++ b/internal/correlation/correlator.go
@@ -27,8 +27,8 @@ func New(fetcher Fetcher, config Config) *Correlator {
 //  3. 각 페어를 PearsonWithLag 로 lag 별 산출
 //  4. 산출 결과를 []CorrelationResult 로 반환
 //
-// 일부 query 가 fetch 실패해도 나머지로 산출을 계속한다. 모든 query 가 실패하면 wrapped error 를
-// 반환한다. fetch 결과가 비어 있는 (시계열 0개) query 는 정상으로 본다.
+// 일부 query 가 fetch 실패해도 나머지로 산출을 계속한다. 모든 query 가 실패할 때만 wrapped error 를
+// 반환한다. fetch 결과가 비어 있는 (시계열 0개) query 는 정상으로 보고 페어 산출에서 자연 제외된다.
 func (c *Correlator) Correlate(ctx context.Context) ([]CorrelationResult, error) {
 	end := time.Now()
 	start := end.Add(-c.config.Window)
@@ -46,7 +46,9 @@ func (c *Correlator) Correlate(ctx context.Context) ([]CorrelationResult, error)
 		}
 		all = append(all, series...)
 	}
-	if len(all) == 0 && len(fetchErrors) > 0 {
+	// 모든 query 가 실패했을 때만 error 로 격상한다. 일부 성공 + 일부 실패 (예: 한 query 가 syntax
+	// 오류 인데 다른 query 들이 정상) 는 부분 결과로 산출을 계속한다.
+	if len(queries) > 0 && len(fetchErrors) == len(queries) {
 		return nil, fmt.Errorf("all %d queries failed: %v", len(queries), fetchErrors)
 	}
 

--- a/internal/correlation/correlator.go
+++ b/internal/correlation/correlator.go
@@ -1,0 +1,61 @@
+package correlation
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Correlator 는 fetcher 로 시계열을 가져와 pair enumerate 후 Pearson 으로 상관계수를 산출하는
+// orchestrator 다. 상태 없이 매 호출이 독립적이라 동일 인스턴스가 여러 호출 간 reuse 가능하다.
+type Correlator struct {
+	fetcher Fetcher
+	config  Config
+}
+
+// New 는 Fetcher 와 Config 로 Correlator 를 구성한다. Fetcher 인터페이스를 받아 단위 테스트에서
+// mock 으로 대체 가능하다.
+func New(fetcher Fetcher, config Config) *Correlator {
+	return &Correlator{fetcher: fetcher, config: config}
+}
+
+// Correlate 는 다음 순서로 산출을 수행한다.
+//
+//  1. config 의 DefaultMetrics 와 ExtraMetrics 를 합쳐 모든 query 를 동일 start / end / step 으로
+//     fetch
+//  2. 모든 LabeledSeries 를 EnumeratePairs 로 노드 한정 페어로 변환
+//  3. 각 페어를 PearsonWithLag 로 lag 별 산출
+//  4. 산출 결과를 []CorrelationResult 로 반환
+//
+// 일부 query 가 fetch 실패해도 나머지로 산출을 계속한다. 모든 query 가 실패하면 wrapped error 를
+// 반환한다. fetch 결과가 비어 있는 (시계열 0개) query 는 정상으로 본다.
+func (c *Correlator) Correlate(ctx context.Context) ([]CorrelationResult, error) {
+	end := time.Now()
+	start := end.Add(-c.config.Window)
+
+	queries := append([]string{}, c.config.DefaultMetrics...)
+	queries = append(queries, c.config.ExtraMetrics...)
+
+	all := make([]LabeledSeries, 0)
+	var fetchErrors []string
+	for _, q := range queries {
+		series, err := c.fetcher.Fetch(ctx, q, start, end, c.config.Step)
+		if err != nil {
+			fetchErrors = append(fetchErrors, fmt.Sprintf("query %q: %v", q, err))
+			continue
+		}
+		all = append(all, series...)
+	}
+	if len(all) == 0 && len(fetchErrors) > 0 {
+		return nil, fmt.Errorf("all %d queries failed: %v", len(queries), fetchErrors)
+	}
+
+	pairs := EnumeratePairs(all)
+	results := make([]CorrelationResult, 0, len(pairs))
+	for _, p := range pairs {
+		r := PearsonWithLag(p.Src, p.Dst, c.config.LagSteps, c.config.MinSamples)
+		r.Pair = p.Key
+		results = append(results, r)
+	}
+	return results, nil
+}

--- a/internal/correlation/correlator.go
+++ b/internal/correlation/correlator.go
@@ -20,18 +20,23 @@ func New(fetcher Fetcher, config Config) *Correlator {
 	return &Correlator{fetcher: fetcher, config: config}
 }
 
-// Correlate 는 다음 순서로 산출을 수행한다.
+// Correlate 는 endTime 을 기준으로 [endTime-Window, endTime] 범위의 산출을 수행한다. endTime 을
+// 호출자가 명시하므로 함수 자체는 결정적이며 (time.Now() 의존성 없음) 단위 테스트와 과거 시점
+// 분석 (예: alert 발화 시점 기준 회귀 분석) 모두 가능하다. 운영자가 \"지금 기준\" 을 의도하면
+// time.Now() 를 호출 인자로 명시한다 (CLI 의 기본 동작).
+//
+// 다음 순서로 산출을 수행한다.
 //
 //  1. config 의 DefaultMetrics 와 ExtraMetrics 를 합쳐 모든 query 를 동일 start / end / step 으로
-//     fetch
+//     병렬 fetch
 //  2. 모든 LabeledSeries 를 EnumeratePairs 로 노드 한정 페어로 변환
 //  3. 각 페어를 PearsonWithLag 로 lag 별 산출
 //  4. 산출 결과를 []CorrelationResult 로 반환
 //
 // 일부 query 가 fetch 실패해도 나머지로 산출을 계속한다. 모든 query 가 실패할 때만 wrapped error 를
 // 반환한다. fetch 결과가 비어 있는 (시계열 0개) query 는 정상으로 보고 페어 산출에서 자연 제외된다.
-func (c *Correlator) Correlate(ctx context.Context) ([]CorrelationResult, error) {
-	end := time.Now()
+func (c *Correlator) Correlate(ctx context.Context, endTime time.Time) ([]CorrelationResult, error) {
+	end := endTime
 	start := end.Add(-c.config.Window)
 
 	queries := append([]string{}, c.config.DefaultMetrics...)

--- a/internal/correlation/correlator.go
+++ b/internal/correlation/correlator.go
@@ -3,6 +3,7 @@ package correlation
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -36,15 +37,33 @@ func (c *Correlator) Correlate(ctx context.Context) ([]CorrelationResult, error)
 	queries := append([]string{}, c.config.DefaultMetrics...)
 	queries = append(queries, c.config.ExtraMetrics...)
 
+	// 각 query 를 goroutine 으로 병렬 fetch 한다. 표준 라이브러리 sync.WaitGroup + 인덱스 기반
+	// 사전 할당 슬라이스로 query 순서를 보존하고 비결정성을 차단한다. 모든 query 가 독립적이고
+	// fetcher 의 http.Client 가 concurrent 안전하므로 추가 동기화는 불필요하다.
+	type fetchResult struct {
+		series []LabeledSeries
+		err    error
+	}
+	fetched := make([]fetchResult, len(queries))
+	var wg sync.WaitGroup
+	for i, q := range queries {
+		wg.Add(1)
+		go func(i int, q string) {
+			defer wg.Done()
+			series, err := c.fetcher.Fetch(ctx, q, start, end, c.config.Step)
+			fetched[i] = fetchResult{series: series, err: err}
+		}(i, q)
+	}
+	wg.Wait()
+
 	all := make([]LabeledSeries, 0)
 	var fetchErrors []string
-	for _, q := range queries {
-		series, err := c.fetcher.Fetch(ctx, q, start, end, c.config.Step)
-		if err != nil {
-			fetchErrors = append(fetchErrors, fmt.Sprintf("query %q: %v", q, err))
+	for i, r := range fetched {
+		if r.err != nil {
+			fetchErrors = append(fetchErrors, fmt.Sprintf("query %q: %v", queries[i], r.err))
 			continue
 		}
-		all = append(all, series...)
+		all = append(all, r.series...)
 	}
 	// 모든 query 가 실패했을 때만 error 로 격상한다. 일부 성공 + 일부 실패 (예: 한 query 가 syntax
 	// 오류 인데 다른 query 들이 정상) 는 부분 결과로 산출을 계속한다.

--- a/internal/correlation/correlator_test.go
+++ b/internal/correlation/correlator_test.go
@@ -135,6 +135,28 @@ func TestCorrelator_AllFetchFailureReturnsError(t *testing.T) {
 	}
 }
 
+// TestCorrelator_PartialFailureWithEmptyResults 는 일부 query 가 실패하고 나머지가 빈 결과 (0
+// series) 를 반환할 때 에러가 아닌 빈 결과로 처리되는지 검증한다. "all 실패" 조건은 query 수와
+// 실패 수가 정확히 일치할 때만 발화한다.
+func TestCorrelator_PartialFailureWithEmptyResults(t *testing.T) {
+	fetcher := &mockFetcher{
+		responses: map[string][]LabeledSeries{
+			"metric_empty": {}, // empty result, but successful
+		},
+		errors: map[string]error{
+			"metric_failing": errors.New("simulated 500"),
+		},
+	}
+	cfg := Config{LagSteps: []int{0}, DefaultMetrics: []string{"metric_empty", "metric_failing"}, MinSamples: 5}
+	results, err := New(fetcher, cfg).Correlate(context.Background())
+	if err != nil {
+		t.Fatalf("err=%v want nil (one success with empty result + one failure must NOT be classified as all-failed)", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("results=%d want 0 (no series → no pairs)", len(results))
+	}
+}
+
 // TestDefaultConfigContainsCorrelationInputs 는 default config 가 본 시리즈의 신규 cause score 와
 // latency / node 메트릭을 포함하는지 검증한다. zero-config 운영의 기반이다.
 func TestDefaultConfigContainsCorrelationInputs(t *testing.T) {

--- a/internal/correlation/correlator_test.go
+++ b/internal/correlation/correlator_test.go
@@ -58,7 +58,7 @@ func TestCorrelator_HappyPath(t *testing.T) {
 		LagSteps:       []int{0},
 		DefaultMetrics: []string{"metric_a", "metric_b"},
 	}
-	results, err := New(fetcher, cfg).Correlate(context.Background())
+	results, err := New(fetcher, cfg).Correlate(context.Background(), time.Now())
 	if err != nil {
 		t.Fatalf("Correlate: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestCorrelator_HappyPath(t *testing.T) {
 func TestCorrelator_EmptyInput(t *testing.T) {
 	fetcher := &mockFetcher{}
 	cfg := Config{DefaultMetrics: []string{"any_metric"}, LagSteps: []int{0}, MinSamples: 5}
-	results, err := New(fetcher, cfg).Correlate(context.Background())
+	results, err := New(fetcher, cfg).Correlate(context.Background(), time.Now())
 	if err != nil {
 		t.Fatalf("Correlate: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestCorrelator_PartialFetchFailure(t *testing.T) {
 		Step: 1 * time.Second, MinSamples: 5, LagSteps: []int{0},
 		DefaultMetrics: []string{"metric_a", "metric_b", "failing_metric"},
 	}
-	results, err := New(fetcher, cfg).Correlate(context.Background())
+	results, err := New(fetcher, cfg).Correlate(context.Background(), time.Now())
 	if err != nil {
 		t.Fatalf("Correlate: %v (one failure should be tolerated)", err)
 	}
@@ -129,7 +129,7 @@ func TestCorrelator_AllFetchFailureReturnsError(t *testing.T) {
 		},
 	}
 	cfg := Config{LagSteps: []int{0}, DefaultMetrics: []string{"metric_a", "metric_b"}, MinSamples: 5}
-	_, err := New(fetcher, cfg).Correlate(context.Background())
+	_, err := New(fetcher, cfg).Correlate(context.Background(), time.Now())
 	if err == nil {
 		t.Errorf("err=nil want non-nil when all queries fail")
 	}
@@ -148,13 +148,52 @@ func TestCorrelator_PartialFailureWithEmptyResults(t *testing.T) {
 		},
 	}
 	cfg := Config{LagSteps: []int{0}, DefaultMetrics: []string{"metric_empty", "metric_failing"}, MinSamples: 5}
-	results, err := New(fetcher, cfg).Correlate(context.Background())
+	results, err := New(fetcher, cfg).Correlate(context.Background(), time.Now())
 	if err != nil {
 		t.Fatalf("err=%v want nil (one success with empty result + one failure must NOT be classified as all-failed)", err)
 	}
 	if len(results) != 0 {
 		t.Errorf("results=%d want 0 (no series → no pairs)", len(results))
 	}
+}
+
+// TestCorrelator_DeterministicEndTime 은 endTime 을 인자로 받아 fetcher 가 정확히 [endTime-Window,
+// endTime] 범위로 query 되는지 검증한다. 함수가 time.Now() 에 의존하지 않아 단위 테스트와 과거
+// 시점 분석이 모두 결정적임을 보장한다.
+func TestCorrelator_DeterministicEndTime(t *testing.T) {
+	fixed := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	window := 10 * time.Minute
+	expectStart := fixed.Add(-window)
+
+	var gotStart, gotEnd time.Time
+	fetcher := &mockFetcher{}
+	fetcher.responses = map[string][]LabeledSeries{}
+	// Recording fetcher 로 호출 시점 캡처.
+	recording := &recordingFetcher{
+		inner: fetcher,
+		onCall: func(start, end time.Time) {
+			gotStart, gotEnd = start, end
+		},
+	}
+	cfg := Config{Window: window, Step: 30 * time.Second, MinSamples: 5, LagSteps: []int{0}, DefaultMetrics: []string{"any"}}
+	_, _ = New(recording, cfg).Correlate(context.Background(), fixed)
+
+	if !gotEnd.Equal(fixed) {
+		t.Errorf("end=%v want %v", gotEnd, fixed)
+	}
+	if !gotStart.Equal(expectStart) {
+		t.Errorf("start=%v want %v", gotStart, expectStart)
+	}
+}
+
+type recordingFetcher struct {
+	inner  Fetcher
+	onCall func(start, end time.Time)
+}
+
+func (r *recordingFetcher) Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error) {
+	r.onCall(start, end)
+	return r.inner.Fetch(ctx, query, start, end, step)
 }
 
 // TestDefaultConfigContainsCorrelationInputs 는 default config 가 본 시리즈의 신규 pod 단위 cause

--- a/internal/correlation/correlator_test.go
+++ b/internal/correlation/correlator_test.go
@@ -1,0 +1,160 @@
+package correlation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mockFetcher 는 query → 미리 등록된 LabeledSeries 슬라이스로 응답한다. 등록되지 않은 query 는
+// errOnMissing 이 true 면 에러 반환, false 면 빈 슬라이스 반환.
+type mockFetcher struct {
+	responses     map[string][]LabeledSeries
+	errors        map[string]error
+	errOnMissing  bool
+	defaultResult []LabeledSeries
+}
+
+func (m *mockFetcher) Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error) {
+	if err, ok := m.errors[query]; ok {
+		return nil, err
+	}
+	if r, ok := m.responses[query]; ok {
+		return r, nil
+	}
+	if m.errOnMissing {
+		return nil, errors.New("query not registered")
+	}
+	return m.defaultResult, nil
+}
+
+func linearSeries(labels map[string]string, n int, base, slope float64) LabeledSeries {
+	out := LabeledSeries{Series: TimeSeries{Labels: labels, Samples: make([]Sample, n)}}
+	for i := 0; i < n; i++ {
+		out.Series.Samples[i] = Sample{TimestampMs: int64(i) * 1000, Value: base + slope*float64(i)}
+	}
+	return out
+}
+
+// TestCorrelator_HappyPath 는 두 메트릭이 노드 단위 페어로 묶여 Pearson 산출까지 무사히 흘러가는지
+// 검증한다. 두 시계열이 동일 선형이므로 lag 0 에서 +1 상관이 잡힌다.
+func TestCorrelator_HappyPath(t *testing.T) {
+	a := linearSeries(map[string]string{"node": "n1", "src_namespace": "ns", "src_pod": "p1"}, 60, 0, 1)
+	a.Metric = "metric_a"
+	b := linearSeries(map[string]string{"node": "n1", "src_namespace": "ns", "src_pod": "p2"}, 60, 0, 2)
+	b.Metric = "metric_b"
+
+	fetcher := &mockFetcher{
+		responses: map[string][]LabeledSeries{
+			"metric_a": {a},
+			"metric_b": {b},
+		},
+	}
+	cfg := Config{
+		Window:         60 * time.Second,
+		Step:           1 * time.Second,
+		MinSamples:     5,
+		LagSteps:       []int{0},
+		DefaultMetrics: []string{"metric_a", "metric_b"},
+	}
+	results, err := New(fetcher, cfg).Correlate(context.Background())
+	if err != nil {
+		t.Fatalf("Correlate: %v", err)
+	}
+	// (a→b) 와 (b→a) 두 페어가 생성되어야 한다.
+	if len(results) != 2 {
+		t.Fatalf("results=%d want 2", len(results))
+	}
+	for _, r := range results {
+		if r.Status != StatusOK {
+			t.Errorf("pair %+v status=%q want ok", r.Pair, r.Status)
+		}
+		if r.MaxAbsValue < 0.99 {
+			t.Errorf("pair %+v max_abs=%v want ~1.0", r.Pair, r.MaxAbsValue)
+		}
+	}
+}
+
+// TestCorrelator_EmptyInput 은 모든 query 가 빈 결과를 반환할 때 빈 results 와 nil error 를
+// 반환하는지 검증한다.
+func TestCorrelator_EmptyInput(t *testing.T) {
+	fetcher := &mockFetcher{}
+	cfg := Config{DefaultMetrics: []string{"any_metric"}, LagSteps: []int{0}, MinSamples: 5}
+	results, err := New(fetcher, cfg).Correlate(context.Background())
+	if err != nil {
+		t.Fatalf("Correlate: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("results=%d want 0", len(results))
+	}
+}
+
+// TestCorrelator_PartialFetchFailure 는 일부 query 가 실패해도 성공한 query 만으로 산출이 계속
+// 되는지 검증한다. 일부 실패는 partial 한 결과를 허용하고 모든 실패만 에러로 본다.
+func TestCorrelator_PartialFetchFailure(t *testing.T) {
+	a := linearSeries(map[string]string{"node": "n1", "src_namespace": "ns", "src_pod": "p1"}, 60, 0, 1)
+	a.Metric = "metric_a"
+	b := linearSeries(map[string]string{"node": "n1", "src_namespace": "ns", "src_pod": "p2"}, 60, 0, 1)
+	b.Metric = "metric_b"
+
+	fetcher := &mockFetcher{
+		responses: map[string][]LabeledSeries{
+			"metric_a": {a},
+			"metric_b": {b},
+		},
+		errors: map[string]error{
+			"failing_metric": errors.New("simulated 500"),
+		},
+	}
+	cfg := Config{
+		Step: 1 * time.Second, MinSamples: 5, LagSteps: []int{0},
+		DefaultMetrics: []string{"metric_a", "metric_b", "failing_metric"},
+	}
+	results, err := New(fetcher, cfg).Correlate(context.Background())
+	if err != nil {
+		t.Fatalf("Correlate: %v (one failure should be tolerated)", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("results=%d want 2 (only successful queries form pairs)", len(results))
+	}
+}
+
+// TestCorrelator_AllFetchFailureReturnsError 는 모든 query 가 실패하면 에러로 변환되는지 검증한다.
+func TestCorrelator_AllFetchFailureReturnsError(t *testing.T) {
+	fetcher := &mockFetcher{
+		errors: map[string]error{
+			"metric_a": errors.New("simulated 500 a"),
+			"metric_b": errors.New("simulated 500 b"),
+		},
+	}
+	cfg := Config{LagSteps: []int{0}, DefaultMetrics: []string{"metric_a", "metric_b"}, MinSamples: 5}
+	_, err := New(fetcher, cfg).Correlate(context.Background())
+	if err == nil {
+		t.Errorf("err=nil want non-nil when all queries fail")
+	}
+}
+
+// TestDefaultConfigContainsCorrelationInputs 는 default config 가 본 시리즈의 신규 cause score 와
+// latency / node 메트릭을 포함하는지 검증한다. zero-config 운영의 기반이다.
+func TestDefaultConfigContainsCorrelationInputs(t *testing.T) {
+	cfg := DefaultConfig()
+	required := []string{
+		"pod:cpu_throttle_score:5m",
+		"pod:memory_pressure_score:5m",
+		"pod:host_compute_stall_score:5m",
+		"node:gpu_idle:5m",
+	}
+	seen := make(map[string]bool, len(cfg.DefaultMetrics))
+	for _, m := range cfg.DefaultMetrics {
+		seen[m] = true
+	}
+	for _, r := range required {
+		if !seen[r] {
+			t.Errorf("DefaultMetrics missing %q", r)
+		}
+	}
+	if cfg.Window <= 0 || cfg.Step <= 0 || cfg.MinSamples <= 0 {
+		t.Errorf("default window/step/minSamples must be positive, got %+v", cfg)
+	}
+}

--- a/internal/correlation/correlator_test.go
+++ b/internal/correlation/correlator_test.go
@@ -157,15 +157,15 @@ func TestCorrelator_PartialFailureWithEmptyResults(t *testing.T) {
 	}
 }
 
-// TestDefaultConfigContainsCorrelationInputs 는 default config 가 본 시리즈의 신규 cause score 와
-// latency / node 메트릭을 포함하는지 검증한다. zero-config 운영의 기반이다.
+// TestDefaultConfigContainsCorrelationInputs 는 default config 가 본 시리즈의 신규 pod 단위 cause
+// score 를 포함하는지 검증한다. zero-config 운영의 기반이다. node-level 메트릭은 namespace / pod
+// 라벨이 없어 EnumeratePairs 의 pod 페어 schema 와 불일치라 default 에서 제외된다.
 func TestDefaultConfigContainsCorrelationInputs(t *testing.T) {
 	cfg := DefaultConfig()
 	required := []string{
 		"pod:cpu_throttle_score:5m",
 		"pod:memory_pressure_score:5m",
 		"pod:host_compute_stall_score:5m",
-		"node:gpu_idle:5m",
 	}
 	seen := make(map[string]bool, len(cfg.DefaultMetrics))
 	for _, m := range cfg.DefaultMetrics {
@@ -174,6 +174,12 @@ func TestDefaultConfigContainsCorrelationInputs(t *testing.T) {
 	for _, r := range required {
 		if !seen[r] {
 			t.Errorf("DefaultMetrics missing %q", r)
+		}
+	}
+	// node-level 메트릭은 default 에서 제외되어야 한다 (Pod 페어 schema 불일치).
+	for _, m := range cfg.DefaultMetrics {
+		if len(m) > 5 && m[:5] == "node:" {
+			t.Errorf("DefaultMetrics should NOT include node-level metric %q (Pod-pair schema mismatch)", m)
 		}
 	}
 	if cfg.Window <= 0 || cfg.Step <= 0 || cfg.MinSamples <= 0 {

--- a/internal/correlation/doc.go
+++ b/internal/correlation/doc.go
@@ -1,7 +1,0 @@
-// Package correlation은 netobs와 gpuobs가 각각 발행하는 Prometheus 지표를
-// 같은 조인 키(node, src_namespace, src_pod, src_pod_uid)로 묶어
-// 네트워크 병목과 GPU 병목을 한 차원에서 분석하기 위한 코드이다.
-//
-// 현재는 의도적으로 비어 있으며, 데이터 수집 조건이 모두 충족된 뒤에 별도 이슈에서 구현을 시작한다.
-// 착수 조건과 계획은 같은 디렉토리의 README.md를 참고한다. (이슈 #7 참고)
-package correlation

--- a/internal/correlation/fetcher.go
+++ b/internal/correlation/fetcher.go
@@ -27,16 +27,21 @@ const maxFetchResponseBytes = 100 << 20
 // /prometheus/client_golang/api 의존성을 도입하지 않아 본 패키지의 외부 의존성을 표준 라이브러리로
 // 한정한다.
 type PrometheusFetcher struct {
-	baseURL string
-	client  *http.Client
+	queryURL *url.URL
+	client   *http.Client
 }
 
 // NewPrometheusFetcher 는 base URL (예: http://localhost:9090) 과 timeout 으로 fetcher 를 만든다.
-// baseURL 의 trailing slash 는 정규화한다.
+// baseURL + /api/v1/query_range 를 startup 시점에 1회 파싱해 Fetch 마다 url.Parse 를 반복하지 않게
+// 한다. 잘못된 URL 이면 panic 으로 즉시 알린다 (생성자 시점이라 호출자가 알아채기 쉬움).
 func NewPrometheusFetcher(baseURL string, timeout time.Duration) *PrometheusFetcher {
+	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/api/v1/query_range")
+	if err != nil {
+		panic(fmt.Sprintf("invalid prometheus base URL %q: %v", baseURL, err))
+	}
 	return &PrometheusFetcher{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		client:  &http.Client{Timeout: timeout},
+		queryURL: u,
+		client:   &http.Client{Timeout: timeout},
 	}
 }
 
@@ -60,13 +65,14 @@ type matrixResultItem struct {
 }
 
 // Fetch 는 query_range API 를 호출해 결과를 []LabeledSeries 로 파싱한다. start / end / step 은
-// 호출자가 결정해 모든 fetch 호출이 동일 값을 받으면 timestamp 정렬이 자동 보장된다.
+// 호출자가 결정해 모든 fetch 호출이 동일 값을 받으면 Prometheus query_range 의 step-aligned
+// timestamp 보장에 따라 응답 시계열들이 자동 정렬된다. 데이터 부재 시 NaN 으로 fill 되어 같은
+// timestamp set 을 유지한다.
 func (f *PrometheusFetcher) Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error) {
-	u, err := url.Parse(f.baseURL + "/api/v1/query_range")
-	if err != nil {
-		return nil, fmt.Errorf("invalid base URL %q: %w", f.baseURL, err)
-	}
-	q := u.Query()
+	// queryURL 은 startup 시점에 1회 파싱되어 보관됨. URL 재사용을 위해 deep-copy 후 query string
+	// 만 갈아끼운다.
+	u := *f.queryURL
+	q := url.Values{}
 	q.Set("query", query)
 	q.Set("start", strconv.FormatFloat(float64(start.UnixNano())/1e9, 'f', 3, 64))
 	q.Set("end", strconv.FormatFloat(float64(end.UnixNano())/1e9, 'f', 3, 64))
@@ -83,12 +89,14 @@ func (f *PrometheusFetcher) Fetch(ctx context.Context, query string, start, end 
 	}
 	defer resp.Body.Close()
 
-	// io.LimitReader 로 응답 body 크기를 maxFetchResponseBytes 로 캡. 정상 응답은 수 MB 라 영향 없음.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchResponseBytes))
+	// io.LimitReader 로 응답 body 크기를 maxFetchResponseBytes+1 까지 읽어 정확히 "한도 초과" 여부를
+	// 판별. 정확히 maxFetchResponseBytes 인 응답은 허용하고 그보다 큰 경우에만 에러로 격상한다.
+	// 정상 응답은 수 MB 라 영향 없는 안전 마진.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read body: %w", err)
 	}
-	if int64(len(body)) >= maxFetchResponseBytes {
+	if int64(len(body)) > maxFetchResponseBytes {
 		return nil, fmt.Errorf("response body exceeded %d bytes (limit reached)", maxFetchResponseBytes)
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/internal/correlation/fetcher.go
+++ b/internal/correlation/fetcher.go
@@ -33,16 +33,17 @@ type PrometheusFetcher struct {
 
 // NewPrometheusFetcher 는 base URL (예: http://localhost:9090) 과 timeout 으로 fetcher 를 만든다.
 // baseURL + /api/v1/query_range 를 startup 시점에 1회 파싱해 Fetch 마다 url.Parse 를 반복하지 않게
-// 한다. 잘못된 URL 이면 panic 으로 즉시 알린다 (생성자 시점이라 호출자가 알아채기 쉬움).
-func NewPrometheusFetcher(baseURL string, timeout time.Duration) *PrometheusFetcher {
+// 한다. 잘못된 URL 이면 wrapped error 를 반환하므로 (panic 이 아님) #51 exporter 같은 장기 실행
+// 프로세스에서 호출자가 graceful 하게 실패 처리 가능하다.
+func NewPrometheusFetcher(baseURL string, timeout time.Duration) (*PrometheusFetcher, error) {
 	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/api/v1/query_range")
 	if err != nil {
-		panic(fmt.Sprintf("invalid prometheus base URL %q: %v", baseURL, err))
+		return nil, fmt.Errorf("invalid prometheus base URL %q: %w", baseURL, err)
 	}
 	return &PrometheusFetcher{
 		queryURL: u,
 		client:   &http.Client{Timeout: timeout},
-	}
+	}, nil
 }
 
 // queryRangeResponse 는 Prometheus query_range API 의 matrix 응답 schema 다.

--- a/internal/correlation/fetcher.go
+++ b/internal/correlation/fetcher.go
@@ -1,0 +1,133 @@
+package correlation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Fetcher 는 정해진 query 와 time range / step 으로 시계열을 가져오는 인터페이스다. correlator 와
+// 분리해 단위 테스트에서 mock 으로 대체할 수 있게 한다.
+type Fetcher interface {
+	Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error)
+}
+
+// PrometheusFetcher 는 /api/v1/query_range 를 직접 net/http 로 호출하는 Fetcher 구현이다. github.com
+// /prometheus/client_golang/api 의존성을 도입하지 않아 본 패키지의 외부 의존성을 표준 라이브러리로
+// 한정한다.
+type PrometheusFetcher struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewPrometheusFetcher 는 base URL (예: http://localhost:9090) 과 timeout 으로 fetcher 를 만든다.
+// baseURL 의 trailing slash 는 정규화한다.
+func NewPrometheusFetcher(baseURL string, timeout time.Duration) *PrometheusFetcher {
+	return &PrometheusFetcher{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: timeout},
+	}
+}
+
+// queryRangeResponse 는 Prometheus query_range API 의 matrix 응답 schema 다.
+// https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+type queryRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string             `json:"resultType"`
+		Result     []matrixResultItem `json:"result"`
+	} `json:"data"`
+	ErrorType string `json:"errorType,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+type matrixResultItem struct {
+	Metric map[string]string `json:"metric"`
+	// Values 는 [[timestamp_seconds, value_string], ...] 형태로 들어온다. timestamp 는 float64,
+	// value 는 string ("NaN", "+Inf", 정상 숫자) 으로 모두 가능하다.
+	Values [][2]json.RawMessage `json:"values"`
+}
+
+// Fetch 는 query_range API 를 호출해 결과를 []LabeledSeries 로 파싱한다. start / end / step 은
+// 호출자가 결정해 모든 fetch 호출이 동일 값을 받으면 timestamp 정렬이 자동 보장된다.
+func (f *PrometheusFetcher) Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error) {
+	u, err := url.Parse(f.baseURL + "/api/v1/query_range")
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL %q: %w", f.baseURL, err)
+	}
+	q := u.Query()
+	q.Set("query", query)
+	q.Set("start", strconv.FormatFloat(float64(start.UnixNano())/1e9, 'f', 3, 64))
+	q.Set("end", strconv.FormatFloat(float64(end.UnixNano())/1e9, 'f', 3, 64))
+	q.Set("step", strconv.FormatFloat(step.Seconds(), 'f', 3, 64))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http get %s: %w", u.String(), err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("prometheus returned status %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var parsed queryRangeResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode json: %w (body: %s)", err, truncate(string(body), 200))
+	}
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("prometheus error: type=%s msg=%s", parsed.ErrorType, parsed.Error)
+	}
+	if parsed.Data.ResultType != "matrix" {
+		return nil, fmt.Errorf("unexpected resultType %q (query_range expects matrix)", parsed.Data.ResultType)
+	}
+
+	out := make([]LabeledSeries, 0, len(parsed.Data.Result))
+	for _, item := range parsed.Data.Result {
+		series := TimeSeries{Labels: item.Metric, Samples: make([]Sample, 0, len(item.Values))}
+		for _, pair := range item.Values {
+			var ts float64
+			if err := json.Unmarshal(pair[0], &ts); err != nil {
+				return nil, fmt.Errorf("decode timestamp: %w", err)
+			}
+			// Prometheus 는 value 를 string 으로 emit 한다. "NaN", "+Inf", "-Inf" 와 일반 숫자 모두
+			// strconv.ParseFloat 가 그대로 받는다.
+			var rawValue string
+			if err := json.Unmarshal(pair[1], &rawValue); err != nil {
+				return nil, fmt.Errorf("decode value: %w", err)
+			}
+			v, err := strconv.ParseFloat(rawValue, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parse value %q: %w", rawValue, err)
+			}
+			series.Samples = append(series.Samples, Sample{
+				TimestampMs: int64(ts * 1000),
+				Value:       v,
+			})
+		}
+		out = append(out, LabeledSeries{Metric: query, Series: series})
+	}
+	return out, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/correlation/fetcher.go
+++ b/internal/correlation/fetcher.go
@@ -18,6 +18,11 @@ type Fetcher interface {
 	Fetch(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]LabeledSeries, error)
 }
 
+// maxFetchResponseBytes 는 단일 query_range 응답에 허용되는 최대 바이트 수다. 1시간 윈도우 / 30초
+// step / 노드당 ~50 Pod / 11 metric 환경에서 정상 응답은 수 MB 수준이라 100MB 는 충분한 안전 마진
+// 이며 Prometheus 이상 동작 (무한 응답 등) 시 메모리 무제한 할당을 차단한다.
+const maxFetchResponseBytes = 100 << 20
+
 // PrometheusFetcher 는 /api/v1/query_range 를 직접 net/http 로 호출하는 Fetcher 구현이다. github.com
 // /prometheus/client_golang/api 의존성을 도입하지 않아 본 패키지의 외부 의존성을 표준 라이브러리로
 // 한정한다.
@@ -78,9 +83,13 @@ func (f *PrometheusFetcher) Fetch(ctx context.Context, query string, start, end 
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	// io.LimitReader 로 응답 body 크기를 maxFetchResponseBytes 로 캡. 정상 응답은 수 MB 라 영향 없음.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(body)) >= maxFetchResponseBytes {
+		return nil, fmt.Errorf("response body exceeded %d bytes (limit reached)", maxFetchResponseBytes)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("prometheus returned status %d: %s", resp.StatusCode, truncate(string(body), 200))

--- a/internal/correlation/fetcher_test.go
+++ b/internal/correlation/fetcher_test.go
@@ -58,7 +58,10 @@ func TestPrometheusFetcher_ParsesMatrixResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	f, err := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
 	got, err := f.Fetch(context.Background(), "up",
 		time.Unix(1700000000, 0), time.Unix(1700000030, 0), 30*time.Second)
 	if err != nil {
@@ -89,7 +92,10 @@ func TestPrometheusFetcher_EmptyResult(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	f, err := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
 	got, err := f.Fetch(context.Background(), "up",
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err != nil {
@@ -107,8 +113,11 @@ func TestPrometheusFetcher_HTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
-	_, err := f.Fetch(context.Background(), "up",
+	f, err := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
+	_, err = f.Fetch(context.Background(), "up",
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err == nil {
 		t.Errorf("err=nil want non-nil for 500 response")
@@ -122,8 +131,11 @@ func TestPrometheusFetcher_BadJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
-	_, err := f.Fetch(context.Background(), "up",
+	f, err := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
+	_, err = f.Fetch(context.Background(), "up",
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err == nil {
 		t.Errorf("err=nil want non-nil for malformed JSON")
@@ -142,8 +154,11 @@ func TestPrometheusFetcher_ResponseSizeLimit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 5*time.Second)
-	_, err := f.Fetch(context.Background(), "up",
+	f, err := NewPrometheusFetcher(srv.URL, 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
+	_, err = f.Fetch(context.Background(), "up",
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err == nil {
 		t.Errorf("err=nil want non-nil for oversized response (>maxFetchResponseBytes)")
@@ -160,8 +175,11 @@ func TestPrometheusFetcher_PrometheusError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
-	_, err := f.Fetch(context.Background(), "syntax !! error",
+	f, err := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NewPrometheusFetcher: %v", err)
+	}
+	_, err = f.Fetch(context.Background(), "syntax !! error",
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err == nil {
 		t.Errorf("err=nil want non-nil for prometheus status=error")

--- a/internal/correlation/fetcher_test.go
+++ b/internal/correlation/fetcher_test.go
@@ -1,0 +1,149 @@
+package correlation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// matrixResponse 는 query_range 정상 응답을 모방하는 helper 다. (timestamp_seconds, value_string)
+// 쌍이 들어온 순서대로 한 series 의 values 로 들어간다. json.Marshal 로 직렬화해 float 포맷 정확성
+// 을 표준 라이브러리에 위임한다.
+func matrixResponse(seriesLabels []map[string]string, valuesBySeries [][][2]any) string {
+	type item struct {
+		Metric map[string]string `json:"metric"`
+		Values [][2]any          `json:"values"`
+	}
+	result := make([]item, len(seriesLabels))
+	for i, labels := range seriesLabels {
+		result[i] = item{Metric: labels, Values: valuesBySeries[i]}
+	}
+	envelope := map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "matrix",
+			"result":     result,
+		},
+	}
+	b, _ := json.Marshal(envelope)
+	return string(b)
+}
+
+// TestPrometheusFetcher_ParsesMatrixResponse 는 정상 query_range 응답을 LabeledSeries 로 정확히
+// 파싱하는지 검증한다.
+func TestPrometheusFetcher_ParsesMatrixResponse(t *testing.T) {
+	resp := matrixResponse(
+		[]map[string]string{
+			{"node": "n1", "src_pod": "p1"},
+			{"node": "n2", "src_pod": "p2"},
+		},
+		[][][2]any{
+			{{1700000000, "1.5"}, {1700000030, "2.5"}},
+			{{1700000000, "3.0"}, {1700000030, "4.0"}},
+		},
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query"); got != "up" {
+			t.Errorf("query=%q want up", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	got, err := f.Fetch(context.Background(), "up",
+		time.Unix(1700000000, 0), time.Unix(1700000030, 0), 30*time.Second)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("series count=%d want 2", len(got))
+	}
+	if got[0].Metric != "up" || got[1].Metric != "up" {
+		t.Errorf("metric must be query string for all series")
+	}
+	if len(got[0].Series.Samples) != 2 {
+		t.Errorf("samples count=%d want 2", len(got[0].Series.Samples))
+	}
+	if got[0].Series.Samples[0].Value != 1.5 || got[0].Series.Samples[1].Value != 2.5 {
+		t.Errorf("samples=%v want [1.5, 2.5]", got[0].Series.Samples)
+	}
+	if got[0].Series.Samples[0].TimestampMs != 1700000000*1000 {
+		t.Errorf("timestamp=%d want 1700000000000", got[0].Series.Samples[0].TimestampMs)
+	}
+}
+
+// TestPrometheusFetcher_EmptyResult 는 query 가 매칭되는 시계열이 없을 때 빈 슬라이스를 반환하고
+// 에러는 내지 않는지 검증한다.
+func TestPrometheusFetcher_EmptyResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	got, err := f.Fetch(context.Background(), "up",
+		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("series count=%d want 0", len(got))
+	}
+}
+
+// TestPrometheusFetcher_HTTPError 는 5xx 응답에서 에러로 변환되는지 검증한다.
+func TestPrometheusFetcher_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	_, err := f.Fetch(context.Background(), "up",
+		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
+	if err == nil {
+		t.Errorf("err=nil want non-nil for 500 response")
+	}
+}
+
+// TestPrometheusFetcher_BadJSON 은 응답이 jSON 디코딩 실패할 때 에러를 반환하는지 검증한다.
+func TestPrometheusFetcher_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json at all`))
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	_, err := f.Fetch(context.Background(), "up",
+		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
+	if err == nil {
+		t.Errorf("err=nil want non-nil for malformed JSON")
+	}
+}
+
+// TestPrometheusFetcher_PrometheusError 는 status=error 응답이 에러로 변환되는지 검증한다.
+func TestPrometheusFetcher_PrometheusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","errorType":"bad_data","error":"parse error at char 5"}`))
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 2*time.Second)
+	_, err := f.Fetch(context.Background(), "syntax !! error",
+		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
+	if err == nil {
+		t.Errorf("err=nil want non-nil for prometheus status=error")
+	}
+	if !strings.Contains(err.Error(), "parse error") {
+		t.Errorf("err=%v want to contain prometheus message", err)
+	}
+}

--- a/internal/correlation/fetcher_test.go
+++ b/internal/correlation/fetcher_test.go
@@ -115,7 +115,7 @@ func TestPrometheusFetcher_HTTPError(t *testing.T) {
 	}
 }
 
-// TestPrometheusFetcher_BadJSON 은 응답이 jSON 디코딩 실패할 때 에러를 반환하는지 검증한다.
+// TestPrometheusFetcher_BadJSON 은 응답이 JSON 디코딩 실패할 때 에러를 반환하는지 검증한다.
 func TestPrometheusFetcher_BadJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`not json at all`))
@@ -127,6 +127,29 @@ func TestPrometheusFetcher_BadJSON(t *testing.T) {
 		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
 	if err == nil {
 		t.Errorf("err=nil want non-nil for malformed JSON")
+	}
+}
+
+// TestPrometheusFetcher_ResponseSizeLimit 는 응답 body 가 maxFetchResponseBytes 를 초과할 때
+// 명시적 에러로 격상되는지 검증한다. 한도 가드가 silently 회귀되지 않도록 guard.
+func TestPrometheusFetcher_ResponseSizeLimit(t *testing.T) {
+	// 한도보다 1바이트 큰 응답을 의도적으로 emit.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// JSON envelope start + 한도 + 1 만큼 padding + 닫는 } 까지 만들어 의도된 크기로 전송.
+		padding := strings.Repeat("a", maxFetchResponseBytes+1)
+		_, _ = w.Write([]byte(`{"padding":"` + padding + `"}`))
+	}))
+	defer srv.Close()
+
+	f := NewPrometheusFetcher(srv.URL, 5*time.Second)
+	_, err := f.Fetch(context.Background(), "up",
+		time.Unix(0, 0), time.Unix(60, 0), 30*time.Second)
+	if err == nil {
+		t.Errorf("err=nil want non-nil for oversized response (>maxFetchResponseBytes)")
+	}
+	if err != nil && !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("err=%v want to contain 'exceeded'", err)
 	}
 }
 

--- a/internal/correlation/pair.go
+++ b/internal/correlation/pair.go
@@ -1,5 +1,7 @@
 package correlation
 
+import "sort"
+
 // LabeledSeries 는 fetcher 가 반환하는 단위로 (metric 이름, 라벨, 시계열) 트리플이다. pair
 // enumeration 이 metric 별 시계열을 노드와 Pod 기준으로 묶어 페어를 만들 때 본 자료를 입력으로
 // 받는다.
@@ -32,52 +34,64 @@ type Pair struct {
 //   - (X, Y) 와 (Y, X) 를 별도 페어로 둘 다 생성한다. 비대칭 분석 (X 자원이 Y latency 를 예측 vs
 //     Y 자원이 X latency 를 예측) 을 위해서다
 //
-// 결과는 결정적 순서 (입력 순서 기반) 로 반환되어 테스트가 안정적으로 비교 가능하다. 사전 할당
-// 슬라이스 cap 은 두지 않는다 (입력 시계열 수의 제곱에 해당하는 cap 은 대형 cluster 에서 OOM 위험).
+// 구현은 노드별 그룹화 후 각 그룹 내에서만 중첩 루프를 돌려 cross-product 비용을 O(N^2) 에서
+// Σ O(N_node^2) 로 감축한다. 노드 키는 정렬 순회해 출력 순서가 결정적이며 단위 테스트가 안정적
+// 으로 비교 가능하다.
+//
+// 사전 할당 슬라이스 cap 은 두지 않는다 (입력 시계열 수의 제곱에 해당하는 cap 은 대형 cluster 에서
+// OOM 위험).
 func EnumeratePairs(items []LabeledSeries) []Pair {
-	out := make([]Pair, 0)
-	for i, src := range items {
-		srcNode := src.Series.Labels["node"]
-		srcNS := src.Series.Labels["src_namespace"]
-		srcPod := src.Series.Labels["src_pod"]
-		if srcNode == "" || srcNS == "" || srcPod == "" {
+	// 1단계: node 키 기준으로 그룹화. 라벨 완비 가드도 같이 적용해 후보 시계열만 그룹에 모은다.
+	byNode := make(map[string][]LabeledSeries)
+	for _, item := range items {
+		node := item.Series.Labels["node"]
+		ns := item.Series.Labels["src_namespace"]
+		pod := item.Series.Labels["src_pod"]
+		if node == "" || ns == "" || pod == "" {
 			continue
 		}
-		srcUID := src.Series.Labels["src_pod_uid"]
-		for j, dst := range items {
-			if i == j {
-				// 같은 (metric, series) 자기 자신과는 비교하지 않는다.
-				continue
+		byNode[node] = append(byNode[node], item)
+	}
+
+	// 노드 키 정렬 (Go map 순회는 비결정적이라 출력 순서 안정성 확보).
+	nodeKeys := make([]string, 0, len(byNode))
+	for k := range byNode {
+		nodeKeys = append(nodeKeys, k)
+	}
+	sort.Strings(nodeKeys)
+
+	// 2단계: 노드별 N_node^2 페어 enumerate.
+	out := make([]Pair, 0)
+	for _, node := range nodeKeys {
+		group := byNode[node]
+		for i, src := range group {
+			srcNS := src.Series.Labels["src_namespace"]
+			srcPod := src.Series.Labels["src_pod"]
+			srcUID := src.Series.Labels["src_pod_uid"]
+			for j, dst := range group {
+				if i == j {
+					continue
+				}
+				dstNS := dst.Series.Labels["src_namespace"]
+				dstPod := dst.Series.Labels["src_pod"]
+				if srcNS == dstNS && srcPod == dstPod && src.Metric == dst.Metric {
+					continue
+				}
+				out = append(out, Pair{
+					Key: PairKey{
+						SrcNamespace: srcNS,
+						SrcPod:       srcPod,
+						SrcPodUID:    srcUID,
+						SrcMetric:    src.Metric,
+						DstNamespace: dstNS,
+						DstPod:       dstPod,
+						DstPodUID:    dst.Series.Labels["src_pod_uid"],
+						DstMetric:    dst.Metric,
+					},
+					Src: src.Series,
+					Dst: dst.Series,
+				})
 			}
-			dstNode := dst.Series.Labels["node"]
-			dstNS := dst.Series.Labels["src_namespace"]
-			dstPod := dst.Series.Labels["src_pod"]
-			if dstNode == "" || dstNS == "" || dstPod == "" {
-				continue
-			}
-			if dstNode != srcNode {
-				// cross-node 제외.
-				continue
-			}
-			if srcNS == dstNS && srcPod == dstPod && src.Metric == dst.Metric {
-				// 같은 Pod 의 동일 metric (즉 동일 시계열의 중복) 만 self 로 본다. 동일 Pod 의 다른
-				// metric 페어는 cause score 와 latency 의 self-correlation 처럼 운영 가치가 있어 유지.
-				continue
-			}
-			out = append(out, Pair{
-				Key: PairKey{
-					SrcNamespace: srcNS,
-					SrcPod:       srcPod,
-					SrcPodUID:    srcUID,
-					SrcMetric:    src.Metric,
-					DstNamespace: dstNS,
-					DstPod:       dstPod,
-					DstPodUID:    dst.Series.Labels["src_pod_uid"],
-					DstMetric:    dst.Metric,
-				},
-				Src: src.Series,
-				Dst: dst.Series,
-			})
 		}
 	}
 	return out

--- a/internal/correlation/pair.go
+++ b/internal/correlation/pair.go
@@ -1,0 +1,73 @@
+package correlation
+
+// LabeledSeries 는 fetcher 가 반환하는 단위로 (metric 이름, 라벨, 시계열) 트리플이다. pair
+// enumeration 이 metric 별 시계열을 노드와 Pod 기준으로 묶어 페어를 만들 때 본 자료를 입력으로
+// 받는다.
+type LabeledSeries struct {
+	// Metric 은 Prometheus query 식별자 (예: "pod:cpu_throttle_score:5m") 다. 동일 metric 의 여러
+	// 시계열 (다른 Pod) 이 본 슬라이스의 별개 entry 로 들어온다.
+	Metric string
+	// Series 는 Labels (node / src_namespace / src_pod / src_pod_uid 등) 와 Samples 를 보유한다.
+	Series TimeSeries
+}
+
+// Pair 는 상관계수 산출 대상이 되는 두 LabeledSeries 의 참조다. PearsonWithLag 의 입력으로 그대로
+// 전달 가능하도록 Src / Dst 두 시계열을 직접 보유한다.
+type Pair struct {
+	Key PairKey
+	Src TimeSeries
+	Dst TimeSeries
+}
+
+// EnumeratePairs 는 입력 LabeledSeries 슬라이스에서 노드 한정 페어를 생성한다. 정책은 다음과 같다.
+//
+//   - 양쪽 모두 동일 node 라벨을 가진 시계열만 페어로 묶는다 (cross-node 제외). node 라벨이 비어
+//     있는 entry 는 pair 후보에서 제외된다
+//   - 양쪽 모두 동일 (src_namespace, src_pod) 인 경우 self-pair 라 제외한다. 같은 Pod 의 두 다른
+//     metric 끼리는 self 가 아니라 metric pair 라 포함된다
+//   - (X, Y) 와 (Y, X) 를 별도 페어로 둘 다 생성한다. 비대칭 분석 (X 자원이 Y latency 를 예측 vs
+//     Y 자원이 X latency 를 예측) 을 위해서다
+//
+// 결과는 결정적 순서 (입력 순서 기반) 로 반환되어 테스트가 안정적으로 비교 가능하다.
+func EnumeratePairs(items []LabeledSeries) []Pair {
+	out := make([]Pair, 0, len(items)*len(items))
+	for i, src := range items {
+		srcNode := src.Series.Labels["node"]
+		if srcNode == "" {
+			continue
+		}
+		srcNS := src.Series.Labels["src_namespace"]
+		srcPod := src.Series.Labels["src_pod"]
+		for j, dst := range items {
+			if i == j {
+				// 같은 (metric, series) 자기 자신과는 비교하지 않는다.
+				continue
+			}
+			dstNode := dst.Series.Labels["node"]
+			if dstNode != srcNode {
+				// cross-node 제외.
+				continue
+			}
+			dstNS := dst.Series.Labels["src_namespace"]
+			dstPod := dst.Series.Labels["src_pod"]
+			if srcNS == dstNS && srcPod == dstPod && src.Metric == dst.Metric {
+				// 같은 Pod 의 동일 metric (즉 동일 시계열의 중복) 만 self 로 본다. 동일 Pod 의 다른
+				// metric 페어는 cause score 와 latency 의 self-correlation 처럼 운영 가치가 있어 유지.
+				continue
+			}
+			out = append(out, Pair{
+				Key: PairKey{
+					SrcNamespace: srcNS,
+					SrcPod:       srcPod,
+					SrcMetric:    src.Metric,
+					DstNamespace: dstNS,
+					DstPod:       dstPod,
+					DstMetric:    dst.Metric,
+				},
+				Src: src.Series,
+				Dst: dst.Series,
+			})
+		}
+	}
+	return out
+}

--- a/internal/correlation/pair.go
+++ b/internal/correlation/pair.go
@@ -19,37 +19,46 @@ type Pair struct {
 	Dst TimeSeries
 }
 
-// EnumeratePairs 는 입력 LabeledSeries 슬라이스에서 노드 한정 페어를 생성한다. 정책은 다음과 같다.
+// EnumeratePairs 는 입력 LabeledSeries 슬라이스에서 노드 한정 Pod 페어를 생성한다. 정책은 다음과
+// 같다.
 //
-//   - 양쪽 모두 동일 node 라벨을 가진 시계열만 페어로 묶는다 (cross-node 제외). node 라벨이 비어
-//     있는 entry 는 pair 후보에서 제외된다
-//   - 양쪽 모두 동일 (src_namespace, src_pod) 인 경우 self-pair 라 제외한다. 같은 Pod 의 두 다른
-//     metric 끼리는 self 가 아니라 metric pair 라 포함된다
+//   - 양쪽 모두 동일 node 라벨을 가진 시계열만 페어로 묶는다 (cross-node 제외)
+//   - node / src_namespace / src_pod 세 라벨이 모두 채워진 시계열만 Pod 페어 후보로 인정한다.
+//     node-level 메트릭 (예: node:gpu_idle:5m 처럼 namespace / pod 라벨이 없는 series) 은 본 패키지의
+//     Pod-pair 산출 schema 와 불일치라 자동 제외되어 빈 Pod 라벨로 emit 되는 false-positive 결과를
+//     차단한다
+//   - 양쪽 모두 동일 (src_namespace, src_pod, metric) 인 경우 self-pair 라 제외한다. 같은 Pod 의
+//     두 다른 metric 끼리는 self 가 아니라 metric pair 라 포함된다
 //   - (X, Y) 와 (Y, X) 를 별도 페어로 둘 다 생성한다. 비대칭 분석 (X 자원이 Y latency 를 예측 vs
 //     Y 자원이 X latency 를 예측) 을 위해서다
 //
-// 결과는 결정적 순서 (입력 순서 기반) 로 반환되어 테스트가 안정적으로 비교 가능하다.
+// 결과는 결정적 순서 (입력 순서 기반) 로 반환되어 테스트가 안정적으로 비교 가능하다. 사전 할당
+// 슬라이스 cap 은 두지 않는다 (입력 시계열 수의 제곱에 해당하는 cap 은 대형 cluster 에서 OOM 위험).
 func EnumeratePairs(items []LabeledSeries) []Pair {
-	out := make([]Pair, 0, len(items)*len(items))
+	out := make([]Pair, 0)
 	for i, src := range items {
 		srcNode := src.Series.Labels["node"]
-		if srcNode == "" {
-			continue
-		}
 		srcNS := src.Series.Labels["src_namespace"]
 		srcPod := src.Series.Labels["src_pod"]
+		if srcNode == "" || srcNS == "" || srcPod == "" {
+			continue
+		}
+		srcUID := src.Series.Labels["src_pod_uid"]
 		for j, dst := range items {
 			if i == j {
 				// 같은 (metric, series) 자기 자신과는 비교하지 않는다.
 				continue
 			}
 			dstNode := dst.Series.Labels["node"]
+			dstNS := dst.Series.Labels["src_namespace"]
+			dstPod := dst.Series.Labels["src_pod"]
+			if dstNode == "" || dstNS == "" || dstPod == "" {
+				continue
+			}
 			if dstNode != srcNode {
 				// cross-node 제외.
 				continue
 			}
-			dstNS := dst.Series.Labels["src_namespace"]
-			dstPod := dst.Series.Labels["src_pod"]
 			if srcNS == dstNS && srcPod == dstPod && src.Metric == dst.Metric {
 				// 같은 Pod 의 동일 metric (즉 동일 시계열의 중복) 만 self 로 본다. 동일 Pod 의 다른
 				// metric 페어는 cause score 와 latency 의 self-correlation 처럼 운영 가치가 있어 유지.
@@ -59,9 +68,11 @@ func EnumeratePairs(items []LabeledSeries) []Pair {
 				Key: PairKey{
 					SrcNamespace: srcNS,
 					SrcPod:       srcPod,
+					SrcPodUID:    srcUID,
 					SrcMetric:    src.Metric,
 					DstNamespace: dstNS,
 					DstPod:       dstPod,
+					DstPodUID:    dst.Series.Labels["src_pod_uid"],
 					DstMetric:    dst.Metric,
 				},
 				Src: src.Series,

--- a/internal/correlation/pair_test.go
+++ b/internal/correlation/pair_test.go
@@ -1,0 +1,126 @@
+package correlation
+
+import (
+	"sort"
+	"testing"
+)
+
+// ls 는 테스트용 LabeledSeries 짧은 생성자다. metric / node / namespace / pod 만 지정하고 시계열
+// 데이터는 의미가 없으니 빈 슬라이스로 둔다.
+func ls(metric, node, ns, pod string) LabeledSeries {
+	return LabeledSeries{
+		Metric: metric,
+		Series: TimeSeries{
+			Labels: map[string]string{
+				"node":          node,
+				"src_namespace": ns,
+				"src_pod":       pod,
+			},
+		},
+	}
+}
+
+// pairKeys 는 EnumeratePairs 결과를 (src→dst) 비교용 정렬된 문자열 슬라이스로 변환한다. 결정적 비교
+// 를 위해 정렬한 결과로 검증한다.
+func pairKeys(ps []Pair) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Key.SrcMetric + "@" + p.Key.SrcNamespace + "/" + p.Key.SrcPod +
+			" -> " + p.Key.DstMetric + "@" + p.Key.DstNamespace + "/" + p.Key.DstPod
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestEnumeratePairsSameNodeOnly 는 동일 노드에 있는 Pod 들끼리만 pair 가 생성되고 cross-node 는
+// 제외되는지 검증한다. 본 정책으로 cross-product N^2 을 노드 단위 N_node^2 로 통제해 cardinality
+// 폭발을 막는다.
+func TestEnumeratePairsSameNodeOnly(t *testing.T) {
+	items := []LabeledSeries{
+		ls("m1", "node-a", "ns", "pod-1"),
+		ls("m1", "node-a", "ns", "pod-2"),
+		ls("m1", "node-b", "ns", "pod-3"),
+	}
+	got := pairKeys(EnumeratePairs(items))
+	want := []string{
+		"m1@ns/pod-1 -> m1@ns/pod-2",
+		"m1@ns/pod-2 -> m1@ns/pod-1",
+	}
+	if !equalStringSlices(got, want) {
+		t.Errorf("\n got=%v\nwant=%v (node-b pod must be excluded)", got, want)
+	}
+}
+
+// TestEnumeratePairsExcludesSelf 는 동일 (metric, namespace, pod) 시계열이 자기 자신과 페어 되지
+// 않는지 검증한다.
+func TestEnumeratePairsExcludesSelf(t *testing.T) {
+	items := []LabeledSeries{
+		ls("m1", "node-a", "ns", "pod-1"),
+		ls("m1", "node-a", "ns", "pod-1"), // duplicate, self
+	}
+	got := EnumeratePairs(items)
+	if len(got) != 0 {
+		t.Errorf("pair count=%d want 0 (identical series must not pair)", len(got))
+	}
+}
+
+// TestEnumeratePairsAsymmetricBothDirections 는 (X, Y) 와 (Y, X) 가 별도 페어로 둘 다 생성되는지
+// 검증한다. 비대칭 분석 (src 자원 → dst latency vs dst 자원 → src latency) 의 기반.
+func TestEnumeratePairsAsymmetricBothDirections(t *testing.T) {
+	items := []LabeledSeries{
+		ls("cpu", "node-a", "ns", "pod-1"),
+		ls("latency", "node-a", "ns", "pod-2"),
+	}
+	got := pairKeys(EnumeratePairs(items))
+	want := []string{
+		"cpu@ns/pod-1 -> latency@ns/pod-2",
+		"latency@ns/pod-2 -> cpu@ns/pod-1",
+	}
+	if !equalStringSlices(got, want) {
+		t.Errorf("\n got=%v\nwant=%v (both directions must exist)", got, want)
+	}
+}
+
+// TestEnumeratePairsSamePodCrossMetric 는 같은 Pod 의 서로 다른 metric 페어 (cause score 와
+// latency) 가 생성되는지 검증한다. 동일 Pod 의 self 정의는 (namespace, pod, metric) 셋 모두 같을
+// 때만 self 로 보고 metric 이 다르면 정상 페어다.
+func TestEnumeratePairsSamePodCrossMetric(t *testing.T) {
+	items := []LabeledSeries{
+		ls("cpu_throttle_score", "node-a", "ns", "pod-1"),
+		ls("latency_p99", "node-a", "ns", "pod-1"),
+	}
+	got := pairKeys(EnumeratePairs(items))
+	want := []string{
+		"cpu_throttle_score@ns/pod-1 -> latency_p99@ns/pod-1",
+		"latency_p99@ns/pod-1 -> cpu_throttle_score@ns/pod-1",
+	}
+	if !equalStringSlices(got, want) {
+		t.Errorf("\n got=%v\nwant=%v (same-pod cross-metric must pair)", got, want)
+	}
+}
+
+// TestEnumeratePairsEmptyNodeLabelExcluded 는 node 라벨이 비어 있는 entry 가 pair 후보에서 제외
+// 되는지 검증한다. node 정보 없는 시계열은 어떤 노드에 속하는지 결정 불가라 cross-node 가드를
+// 적용할 수 없다.
+func TestEnumeratePairsEmptyNodeLabelExcluded(t *testing.T) {
+	items := []LabeledSeries{
+		{Metric: "m1", Series: TimeSeries{Labels: map[string]string{"src_namespace": "ns", "src_pod": "pod-1"}}},
+		ls("m1", "node-a", "ns", "pod-2"),
+	}
+	got := EnumeratePairs(items)
+	if len(got) != 0 {
+		t.Errorf("pair count=%d want 0 (entries without node label must be excluded)", len(got))
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/correlation/pair_test.go
+++ b/internal/correlation/pair_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 // ls 는 테스트용 LabeledSeries 짧은 생성자다. metric / node / namespace / pod 만 지정하고 시계열
-// 데이터는 의미가 없으니 빈 슬라이스로 둔다.
+// 데이터는 의미가 없으니 빈 슬라이스로 둔다. UID 는 namespace + pod 기준의 deterministic stub 으로
+// PairKey assert 에서도 사용 가능하다.
 func ls(metric, node, ns, pod string) LabeledSeries {
 	return LabeledSeries{
 		Metric: metric,
@@ -15,6 +16,7 @@ func ls(metric, node, ns, pod string) LabeledSeries {
 				"node":          node,
 				"src_namespace": ns,
 				"src_pod":       pod,
+				"src_pod_uid":   "uid-" + ns + "-" + pod,
 			},
 		},
 	}
@@ -110,6 +112,46 @@ func TestEnumeratePairsEmptyNodeLabelExcluded(t *testing.T) {
 	got := EnumeratePairs(items)
 	if len(got) != 0 {
 		t.Errorf("pair count=%d want 0 (entries without node label must be excluded)", len(got))
+	}
+}
+
+// TestEnumeratePairsNodeLevelMetricExcluded 는 node 라벨만 있고 namespace / pod 라벨이 없는
+// node-level 메트릭 (예: node:gpu_idle:5m) 이 Pod 페어 후보에서 제외되는지 검증한다. PairKey 의
+// schema 가 Pod 페어 기반이라 namespace / pod 가 빈 series 와의 페어는 schema 거짓말이 되어 제외
+// 가 필요하다.
+func TestEnumeratePairsNodeLevelMetricExcluded(t *testing.T) {
+	items := []LabeledSeries{
+		// node-level series: node 만 있고 namespace / pod 라벨 없음
+		{Metric: "node:gpu_idle:5m", Series: TimeSeries{Labels: map[string]string{"node": "node-a"}}},
+		ls("pod:cpu:5m", "node-a", "ns", "pod-1"),
+	}
+	got := EnumeratePairs(items)
+	if len(got) != 0 {
+		t.Errorf("pair count=%d want 0 (node-level series must not pair with pod series)", len(got))
+	}
+}
+
+// TestEnumeratePairsPreservesPodUID 는 src_pod_uid 라벨이 PairKey 의 SrcPodUID / DstPodUID 로
+// 정확히 전달되는지 검증한다. #51 exporter 가 UID 라벨로 시계열을 식별해야 하므로 결과 schema 에
+// UID 가 누락되면 안 된다.
+func TestEnumeratePairsPreservesPodUID(t *testing.T) {
+	items := []LabeledSeries{
+		ls("m1", "node-a", "ns", "pod-1"), // uid-ns-pod-1
+		ls("m2", "node-a", "ns", "pod-2"), // uid-ns-pod-2
+	}
+	pairs := EnumeratePairs(items)
+	if len(pairs) != 2 {
+		t.Fatalf("pair count=%d want 2", len(pairs))
+	}
+	for _, p := range pairs {
+		if p.Key.SrcPodUID == "" || p.Key.DstPodUID == "" {
+			t.Errorf("pair %+v missing UID", p.Key)
+		}
+		wantSrc := "uid-ns-" + p.Key.SrcPod
+		wantDst := "uid-ns-" + p.Key.DstPod
+		if p.Key.SrcPodUID != wantSrc || p.Key.DstPodUID != wantDst {
+			t.Errorf("UIDs=%q/%q want %q/%q", p.Key.SrcPodUID, p.Key.DstPodUID, wantSrc, wantDst)
+		}
 	}
 }
 

--- a/internal/correlation/pearson.go
+++ b/internal/correlation/pearson.go
@@ -104,13 +104,18 @@ func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) Correlation
 
 		switch status {
 		case StatusOK:
-			anyOK = true
 			result.CorrelationByLag[lag] = corr
-			if absVal := math.Abs(corr); absVal > maxAbs {
+			absVal := math.Abs(corr)
+			// 첫 OK lag 는 anyOK==false 인 시점이라 무조건 채택한다. 이후 lag 는 절대값이 더 큰 경우
+			// 갱신. 모든 lag 의 corr 이 정확히 0 인 케이스에서도 첫 OK lag 의 sample count 와 lag 가
+			// MaxAbsSampleCount / MaxAbsLag 에 기록되어 SampleCount=0 / MaxAbsLag=0 (lagSteps 에 0 이
+			// 없을 때) 같은 schema 거짓말을 차단한다.
+			if !anyOK || absVal > maxAbs {
 				maxAbs = absVal
 				maxAbsLag = lag
 				maxAbsSampleCount = effective
 			}
+			anyOK = true
 		case StatusSkippedConstant:
 			anyConstant = true
 		case StatusSkippedLowSamples:

--- a/internal/correlation/pearson.go
+++ b/internal/correlation/pearson.go
@@ -167,7 +167,7 @@ func applyLag(a, b TimeSeries, lag int) (TimeSeries, TimeSeries) {
 	}
 	return TimeSeries{
 			Labels:  a.Labels,
-			Samples: a.Samples[-lag : n],
+			Samples: a.Samples[-lag:n],
 		}, TimeSeries{
 			Labels:  b.Labels,
 			Samples: b.Samples[:n+lag],

--- a/internal/correlation/pearson.go
+++ b/internal/correlation/pearson.go
@@ -1,0 +1,175 @@
+package correlation
+
+import (
+	"math"
+)
+
+// Pearson은 두 시계열의 lag 0 피어슨 상관계수를 산출한다. 산출 결과는 -1 에서 1 사이의 값이며 양
+// 끝에서 강한 양 / 음 상관, 0 부근에서 무상관을 의미한다.
+//
+// 본 함수의 가드 규칙은 다음과 같다.
+//   - NaN / Inf 가 한쪽이라도 있는 timestamp 는 pairwise 로 제거한다 (Prometheus 가 가끔 NaN 을
+//     emit 하는 케이스 대응)
+//   - length mismatch 가 있으면 짧은 쪽 기준으로 truncate 해 동일 길이로 맞춘다 (Prometheus 가
+//     start/end 정렬돼도 query 응답이 부분적으로 비는 케이스 대응)
+//   - 유효 표본 수가 minSamples 미만이면 (0, StatusSkippedLowSamples) 반환
+//   - 두 시계열 중 하나라도 분산이 0 (모든 샘플이 같은 값) 이면 Pearson 정의상 분모가 0이라 NaN 이
+//     되는데 본 함수는 (0, StatusSkippedConstant) 로 명시적 fallback 한다
+//   - 정상 산출 시 (value, StatusOK) 반환
+//
+// 입력은 sample 의 Value 만 사용한다 (timestamp 정렬은 호출자가 보장). nil / empty 입력은 length
+// 0 으로 취급되어 minSamples 가드에 걸린다.
+func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
+	// 짧은 쪽 길이를 기준으로 잡아 length mismatch 가 있어도 같은 길이로 맞춘다.
+	n := len(a.Samples)
+	if len(b.Samples) < n {
+		n = len(b.Samples)
+	}
+
+	// NaN / Inf 가 어느 한쪽이라도 있는 timestamp 는 pairwise 제거. 결과는 sanitized 두 슬라이스.
+	xs := make([]float64, 0, n)
+	ys := make([]float64, 0, n)
+	for i := 0; i < n; i++ {
+		x := a.Samples[i].Value
+		y := b.Samples[i].Value
+		if math.IsNaN(x) || math.IsInf(x, 0) || math.IsNaN(y) || math.IsInf(y, 0) {
+			continue
+		}
+		xs = append(xs, x)
+		ys = append(ys, y)
+	}
+
+	if len(xs) < minSamples {
+		return 0, StatusSkippedLowSamples
+	}
+
+	// 평균.
+	var sumX, sumY float64
+	for i := range xs {
+		sumX += xs[i]
+		sumY += ys[i]
+	}
+	count := float64(len(xs))
+	meanX := sumX / count
+	meanY := sumY / count
+
+	// 분자 (공분산 ×N) 와 분모 (각 표본 표준편차 제곱합) 한 번에 누적.
+	var num, denomX, denomY float64
+	for i := range xs {
+		dx := xs[i] - meanX
+		dy := ys[i] - meanY
+		num += dx * dy
+		denomX += dx * dx
+		denomY += dy * dy
+	}
+
+	// 분산 0 가드. 두 시계열 중 하나라도 상수면 Pearson 분모 = 0 이라 NaN. 명시적 0 fallback.
+	if denomX == 0 || denomY == 0 {
+		return 0, StatusSkippedConstant
+	}
+
+	corr := num / math.Sqrt(denomX*denomY)
+	return corr, StatusOK
+}
+
+// PearsonWithLag 는 lag 시점 여러 개에 대해 Pearson 을 동시 산출하고 최대 절대값을 채택한다.
+// lag k 는 cross-correlation 관례에 따라 "a 가 b 를 k step 앞선다" 를 뜻한다. 즉 corr(a[t], b[t+k])
+// 를 산출하며 k 가 양수면 a 의 변동이 b 에 k 시점 뒤 나타나는 propagation 관계 (예: CPU 부하 발생
+// 후 GPU latency 가 30s 뒤 올라가면 lag=+1 에서 최대 상관) 를 가리킨다.
+//
+// shift 결과 길이가 minSamples 미만이 되는 lag 는 산출에서 제외한다. 일부 lag 만 산출 가능한 경우
+// status 는 StatusPartial 이며 산출 가능한 lag 중에서만 최대 절대값을 채택한다.
+//
+// 모든 lag 가 산출 불가면 SampleCount=0, MaxAbsValue=0, status=StatusSkippedLowSamples 를 반환한다.
+// 모든 lag 가 분산 0 으로 막히면 status=StatusSkippedConstant 다.
+func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) CorrelationResult {
+	result := CorrelationResult{
+		CorrelationByLag: make(map[int]float64),
+	}
+
+	var maxAbs float64
+	var maxAbsLag int
+	var anyOK, anyConstant, anyLowSamples bool
+	var sampleCount int
+
+	for _, lag := range lagSteps {
+		shiftedA, shiftedB := applyLag(a, b, lag)
+		corr, status := Pearson(shiftedA, shiftedB, minSamples)
+
+		switch status {
+		case StatusOK:
+			anyOK = true
+			result.CorrelationByLag[lag] = corr
+			if absVal := math.Abs(corr); absVal > maxAbs {
+				maxAbs = absVal
+				maxAbsLag = lag
+			}
+			if cur := len(shiftedA.Samples); cur < len(shiftedB.Samples) {
+				if cur > sampleCount {
+					sampleCount = cur
+				}
+			} else if len(shiftedB.Samples) > sampleCount {
+				sampleCount = len(shiftedB.Samples)
+			}
+		case StatusSkippedConstant:
+			anyConstant = true
+		case StatusSkippedLowSamples:
+			anyLowSamples = true
+		}
+	}
+
+	result.MaxAbsLag = maxAbsLag
+	result.MaxAbsValue = maxAbs
+	result.SampleCount = sampleCount
+
+	switch {
+	case anyOK && (anyConstant || anyLowSamples):
+		result.Status = StatusPartial
+	case anyOK:
+		result.Status = StatusOK
+	case anyConstant:
+		result.Status = StatusSkippedConstant
+	default:
+		result.Status = StatusSkippedLowSamples
+	}
+	return result
+}
+
+// applyLag 는 두 시계열을 lag step 만큼 shift 해 정렬된 페어를 만든다. cross-correlation 관례에
+// 따라 lag k > 0 은 corr(a[t], b[t+k]) 를 계산하므로 a 의 뒤쪽 k 개를, b 의 앞쪽 k 개를 잘라 동일
+// 길이의 (a[0..n-k-1], b[k..n-1]) 페어를 만든다. lag k < 0 은 반대 방향이다. 결과 시계열의 Labels
+// 는 입력을 그대로 보존한다.
+func applyLag(a, b TimeSeries, lag int) (TimeSeries, TimeSeries) {
+	if lag == 0 {
+		return a, b
+	}
+	la, lb := len(a.Samples), len(b.Samples)
+	n := la
+	if lb < n {
+		n = lb
+	}
+	absLag := lag
+	if absLag < 0 {
+		absLag = -absLag
+	}
+	if absLag >= n {
+		return TimeSeries{Labels: a.Labels}, TimeSeries{Labels: b.Labels}
+	}
+
+	if lag > 0 {
+		return TimeSeries{
+				Labels:  a.Labels,
+				Samples: a.Samples[:n-lag],
+			}, TimeSeries{
+				Labels:  b.Labels,
+				Samples: b.Samples[lag:n],
+			}
+	}
+	return TimeSeries{
+			Labels:  a.Labels,
+			Samples: a.Samples[-lag : n],
+		}, TimeSeries{
+			Labels:  b.Labels,
+			Samples: b.Samples[:n+lag],
+		}
+}

--- a/internal/correlation/pearson.go
+++ b/internal/correlation/pearson.go
@@ -4,22 +4,24 @@ import (
 	"math"
 )
 
-// Pearson은 두 시계열의 lag 0 피어슨 상관계수를 산출한다. 산출 결과는 -1 에서 1 사이의 값이며 양
-// 끝에서 강한 양 / 음 상관, 0 부근에서 무상관을 의미한다.
+// Pearson은 두 시계열의 lag 0 피어슨 상관계수를 산출한다. 결과는 (corr, effectiveSamples, status)
+// 트리플이며 corr 은 -1 ~ 1 사이 값, effectiveSamples 는 NaN / Inf pairwise 제거 후 실제 산출에
+// 사용된 유효 표본 수다. CorrelationResult.SampleCount 가 본 값을 그대로 보고하므로 해당 schema
+// 의미와 정합된다.
 //
 // 본 함수의 가드 규칙은 다음과 같다.
 //   - NaN / Inf 가 한쪽이라도 있는 timestamp 는 pairwise 로 제거한다 (Prometheus 가 가끔 NaN 을
 //     emit 하는 케이스 대응)
 //   - length mismatch 가 있으면 짧은 쪽 기준으로 truncate 해 동일 길이로 맞춘다 (Prometheus 가
 //     start/end 정렬돼도 query 응답이 부분적으로 비는 케이스 대응)
-//   - 유효 표본 수가 minSamples 미만이면 (0, StatusSkippedLowSamples) 반환
+//   - 유효 표본 수가 minSamples 미만이면 (0, effectiveSamples, StatusSkippedLowSamples) 반환
 //   - 두 시계열 중 하나라도 분산이 0 (모든 샘플이 같은 값) 이면 Pearson 정의상 분모가 0이라 NaN 이
-//     되는데 본 함수는 (0, StatusSkippedConstant) 로 명시적 fallback 한다
-//   - 정상 산출 시 (value, StatusOK) 반환
+//     되는데 본 함수는 (0, effectiveSamples, StatusSkippedConstant) 로 명시적 fallback 한다
+//   - 정상 산출 시 (value, effectiveSamples, StatusOK) 반환
 //
 // 입력은 sample 의 Value 만 사용한다 (timestamp 정렬은 호출자가 보장). nil / empty 입력은 length
 // 0 으로 취급되어 minSamples 가드에 걸린다.
-func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
+func Pearson(a, b TimeSeries, minSamples int) (float64, int, Status) {
 	// 짧은 쪽 길이를 기준으로 잡아 length mismatch 가 있어도 같은 길이로 맞춘다.
 	n := len(a.Samples)
 	if len(b.Samples) < n {
@@ -39,8 +41,9 @@ func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
 		ys = append(ys, y)
 	}
 
-	if len(xs) < minSamples {
-		return 0, StatusSkippedLowSamples
+	effective := len(xs)
+	if effective < minSamples {
+		return 0, effective, StatusSkippedLowSamples
 	}
 
 	// 평균.
@@ -49,7 +52,7 @@ func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
 		sumX += xs[i]
 		sumY += ys[i]
 	}
-	count := float64(len(xs))
+	count := float64(effective)
 	meanX := sumX / count
 	meanY := sumY / count
 
@@ -65,11 +68,11 @@ func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
 
 	// 분산 0 가드. 두 시계열 중 하나라도 상수면 Pearson 분모 = 0 이라 NaN. 명시적 0 fallback.
 	if denomX == 0 || denomY == 0 {
-		return 0, StatusSkippedConstant
+		return 0, effective, StatusSkippedConstant
 	}
 
 	corr := num / math.Sqrt(denomX*denomY)
-	return corr, StatusOK
+	return corr, effective, StatusOK
 }
 
 // PearsonWithLag 는 lag 시점 여러 개에 대해 Pearson 을 동시 산출하고 최대 절대값을 채택한다.
@@ -80,6 +83,9 @@ func Pearson(a, b TimeSeries, minSamples int) (float64, Status) {
 // shift 결과 길이가 minSamples 미만이 되는 lag 는 산출에서 제외한다. 일부 lag 만 산출 가능한 경우
 // status 는 StatusPartial 이며 산출 가능한 lag 중에서만 최대 절대값을 채택한다.
 //
+// 반환되는 SampleCount 는 MaxAbsLag 가 가리키는 lag 의 유효 표본 수 (NaN / Inf pairwise 제거 후)
+// 다. lag 별 표본 수가 다를 수 있어 운영자가 채택된 lag 의 신뢰도를 직접 판단 가능하게 한다.
+//
 // 모든 lag 가 산출 불가면 SampleCount=0, MaxAbsValue=0, status=StatusSkippedLowSamples 를 반환한다.
 // 모든 lag 가 분산 0 으로 막히면 status=StatusSkippedConstant 다.
 func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) CorrelationResult {
@@ -89,12 +95,12 @@ func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) Correlation
 
 	var maxAbs float64
 	var maxAbsLag int
+	var maxAbsSampleCount int
 	var anyOK, anyConstant, anyLowSamples bool
-	var sampleCount int
 
 	for _, lag := range lagSteps {
 		shiftedA, shiftedB := applyLag(a, b, lag)
-		corr, status := Pearson(shiftedA, shiftedB, minSamples)
+		corr, effective, status := Pearson(shiftedA, shiftedB, minSamples)
 
 		switch status {
 		case StatusOK:
@@ -103,13 +109,7 @@ func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) Correlation
 			if absVal := math.Abs(corr); absVal > maxAbs {
 				maxAbs = absVal
 				maxAbsLag = lag
-			}
-			if cur := len(shiftedA.Samples); cur < len(shiftedB.Samples) {
-				if cur > sampleCount {
-					sampleCount = cur
-				}
-			} else if len(shiftedB.Samples) > sampleCount {
-				sampleCount = len(shiftedB.Samples)
+				maxAbsSampleCount = effective
 			}
 		case StatusSkippedConstant:
 			anyConstant = true
@@ -120,7 +120,7 @@ func PearsonWithLag(a, b TimeSeries, lagSteps []int, minSamples int) Correlation
 
 	result.MaxAbsLag = maxAbsLag
 	result.MaxAbsValue = maxAbs
-	result.SampleCount = sampleCount
+	result.SampleCount = maxAbsSampleCount
 
 	switch {
 	case anyOK && (anyConstant || anyLowSamples):

--- a/internal/correlation/pearson_test.go
+++ b/internal/correlation/pearson_test.go
@@ -208,6 +208,27 @@ func TestPearsonWithLagPartialStatus(t *testing.T) {
 	}
 }
 
+// TestPearsonWithLagAllZeroCorrelationStillSelectsFirstOK 는 모든 lag 의 산출 corr 가 정확히 0 인
+// 케이스에서도 첫 OK lag 가 채택되어 SampleCount 가 0 이 아닌 실제 effectiveSamples 로 보고되는지
+// 검증한다. 기존 구현은 absVal > maxAbs (초기값 0) 가 0 > 0 = false 라 모든 lag 가 skip 되어
+// SampleCount=0 / MaxAbsLag=0 schema 거짓말이 발생했다.
+func TestPearsonWithLagAllZeroCorrelationStillSelectsFirstOK(t *testing.T) {
+	// 두 시계열이 모두 완벽 직교 (corr=0) 이도록 조작. 예: a 는 (1,-1,1,-1,...) b 는 (1,1,-1,-1,...)
+	a := TimeSeries{Samples: samples(1, -1, 1, -1, 1, -1, 1, -1)}
+	b := TimeSeries{Samples: samples(1, 1, -1, -1, 1, 1, -1, -1)}
+	got := PearsonWithLag(a, b, []int{-1, 0, 1}, 3)
+	if got.Status != StatusOK {
+		t.Fatalf("status=%q want %q", got.Status, StatusOK)
+	}
+	if got.SampleCount == 0 {
+		t.Errorf("SampleCount=0 want non-zero (first OK lag must be selected even when all corr=0)")
+	}
+	// MaxAbsLag 은 첫 OK lag (=-1, lagSteps 순서) 이어야 한다.
+	if got.MaxAbsLag != -1 {
+		t.Errorf("MaxAbsLag=%d want -1 (first OK lag in iteration order)", got.MaxAbsLag)
+	}
+}
+
 // TestPearsonWithLagSampleCountReflectsChosenLag 는 SampleCount 가 MaxAbsLag 가 가리키는 lag 의
 // 유효 표본 수임을 검증한다. lag 별로 표본 수가 다를 때 (lag = ±1 은 lag=0 보다 1 sample 적음)
 // 채택된 lag 의 sample count 가 reporting 된다.

--- a/internal/correlation/pearson_test.go
+++ b/internal/correlation/pearson_test.go
@@ -26,7 +26,7 @@ func approxEqual(a, b, tol float64) bool {
 func TestPearsonCorrelationPlusOne(t *testing.T) {
 	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
 	b := TimeSeries{Samples: samples(5, 7, 9, 11, 13, 15, 17, 19, 21, 23)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q", status, StatusOK)
 	}
@@ -39,7 +39,7 @@ func TestPearsonCorrelationPlusOne(t *testing.T) {
 func TestPearsonCorrelationMinusOne(t *testing.T) {
 	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
 	b := TimeSeries{Samples: samples(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q", status, StatusOK)
 	}
@@ -54,7 +54,7 @@ func TestPearsonCorrelationMinusOne(t *testing.T) {
 func TestPearsonCorrelationZero(t *testing.T) {
 	a := TimeSeries{Samples: samples(-1, 1, -1, 1, -1, 1, -1, 1)}
 	b := TimeSeries{Samples: samples(1, 2, 3, 4, 4, 3, 2, 1)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q", status, StatusOK)
 	}
@@ -70,7 +70,7 @@ func TestPearsonCorrelationModerate(t *testing.T) {
 	// b 는 a 와 같은 추세지만 매 timestamp 마다 다른 잡음을 추가해 완벽 +1 이 아닌 0.5-0.9 사이 상관
 	// 을 의도적으로 만든다.
 	b := TimeSeries{Samples: samples(3, 1, 4, 2, 6, 5, 9, 6, 8, 10)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q", status, StatusOK)
 	}
@@ -85,7 +85,7 @@ func TestPearsonCorrelationModerate(t *testing.T) {
 func TestPearsonStddevZeroReturnsConstantStatus(t *testing.T) {
 	a := TimeSeries{Samples: samples(5, 5, 5, 5, 5, 5)} // 상수
 	b := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusSkippedConstant {
 		t.Errorf("status=%q want %q", status, StatusSkippedConstant)
 	}
@@ -102,7 +102,7 @@ func TestPearsonStddevZeroReturnsConstantStatus(t *testing.T) {
 func TestPearsonLowSamplesSkipped(t *testing.T) {
 	a := TimeSeries{Samples: samples(1, 2)}
 	b := TimeSeries{Samples: samples(3, 4)}
-	got, status := Pearson(a, b, 5)
+	got, _, status := Pearson(a, b, 5)
 	if status != StatusSkippedLowSamples {
 		t.Errorf("status=%q want %q", status, StatusSkippedLowSamples)
 	}
@@ -124,7 +124,7 @@ func TestPearsonNilEmptyInputs(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, status := Pearson(c.a, c.b, 3)
+			got, _, status := Pearson(c.a, c.b, 3)
 			if status != StatusSkippedLowSamples {
 				t.Errorf("status=%q want %q", status, StatusSkippedLowSamples)
 			}
@@ -141,7 +141,7 @@ func TestPearsonLengthMismatchTruncates(t *testing.T) {
 	// a 는 6 개, b 는 4 개. 짧은 b 길이 4 로 truncate 되어 (1,2,3,4) 와 (1,2,3,4) 만 비교 → +1.
 	a := TimeSeries{Samples: samples(1, 2, 3, 4, 99, 100)}
 	b := TimeSeries{Samples: samples(1, 2, 3, 4)}
-	got, status := Pearson(a, b, 3)
+	got, _, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q (length mismatch should truncate, not skip)", status, StatusOK)
 	}
@@ -152,10 +152,11 @@ func TestPearsonLengthMismatchTruncates(t *testing.T) {
 
 // TestPearsonNaNInfPairwiseRemoval 은 한쪽 시계열에 NaN / Inf 가 섞여 있을 때 해당 timestamp 만
 // 제거하고 나머지로 산출하는지 검증한다. Prometheus 가 가끔 데이터 공백 timestamp 에 NaN 을 emit
-// 하는 케이스에 대한 가드다.
+// 하는 케이스에 대한 가드다. 유효 표본 수 (NaN / Inf 제거 후) 가 함께 반환되어야 schema 의 sample
+// count 의미가 정합된다.
 func TestPearsonNaNInfPairwiseRemoval(t *testing.T) {
 	// 두 시계열은 실제로 +1 상관이지만 a 의 2번째 sample 이 NaN, b 의 5번째가 +Inf 라 두 timestamp
-	// 가 pairwise 제거되어 (1,3,4,7) 와 (1,3,4,7) 만 비교 → 여전히 +1.
+	// 가 pairwise 제거되어 (1,3,4,7) 와 (1,3,4,7) 만 비교 → 여전히 +1, effectiveSamples = 5.
 	a := TimeSeries{Samples: []Sample{
 		{TimestampMs: 0, Value: 1},
 		{TimestampMs: 1, Value: math.NaN()},
@@ -174,12 +175,52 @@ func TestPearsonNaNInfPairwiseRemoval(t *testing.T) {
 		{TimestampMs: 5, Value: 6},
 		{TimestampMs: 6, Value: 7},
 	}}
-	got, status := Pearson(a, b, 3)
+	got, n, status := Pearson(a, b, 3)
 	if status != StatusOK {
 		t.Fatalf("status=%q want %q (NaN/Inf must be pairwise-removed, not poison the result)", status, StatusOK)
 	}
 	if !approxEqual(got, 1.0, 1e-9) {
 		t.Errorf("corr=%v want 1.0 (5 clean pairs all linear)", got)
+	}
+	if n != 5 {
+		t.Errorf("effectiveSamples=%d want 5 (7 input, 2 removed)", n)
+	}
+}
+
+// TestPearsonWithLagPartialStatus 는 일부 lag 만 산출 가능할 때 (다른 lag 가 표본 부족 또는 상수
+// 시계열로 막힌 경우) Status 가 StatusPartial 로 떨어지는지 검증한다. minSamples = 4 로 두면 lag=+1
+// shift 결과 4개 (a 의 4-9 와 b 의 5-9, 단 b 의 처음 4 sample 은 상수라 lag 0 / -1 분산 0) 가 산출
+// 가능 / 다른 lag 는 표본 부족으로 partial 분기.
+func TestPearsonWithLagPartialStatus(t *testing.T) {
+	// 5 sample 만 있는 a 와 b. lag=0 에서 5 sample 비교 → 산출 가능. lag=+1 에서는 4 sample 비교 →
+	// minSamples=5 이므로 lag=+1 만 부족. partial status 가 떨어진다.
+	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5)}
+	b := TimeSeries{Samples: samples(1, 2, 3, 4, 5)}
+	got := PearsonWithLag(a, b, []int{0, 1}, 5)
+	if got.Status != StatusPartial {
+		t.Errorf("status=%q want %q (lag 0 산출 가능 + lag +1 표본 부족)", got.Status, StatusPartial)
+	}
+	if _, ok := got.CorrelationByLag[0]; !ok {
+		t.Errorf("lag 0 should be in CorrelationByLag")
+	}
+	if _, ok := got.CorrelationByLag[1]; ok {
+		t.Errorf("lag +1 should NOT be in CorrelationByLag (skipped low samples)")
+	}
+}
+
+// TestPearsonWithLagSampleCountReflectsChosenLag 는 SampleCount 가 MaxAbsLag 가 가리키는 lag 의
+// 유효 표본 수임을 검증한다. lag 별로 표본 수가 다를 때 (lag = ±1 은 lag=0 보다 1 sample 적음)
+// 채택된 lag 의 sample count 가 reporting 된다.
+func TestPearsonWithLagSampleCountReflectsChosenLag(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 5, 2, 8, 3, 7, 4, 6, 9, 10)}
+	b := TimeSeries{Samples: samples(0, 1, 5, 2, 8, 3, 7, 4, 6, 9)} // a leads b by 1
+	got := PearsonWithLag(a, b, []int{-1, 0, 1}, 3)
+	if got.MaxAbsLag != 1 {
+		t.Fatalf("MaxAbsLag=%d want 1", got.MaxAbsLag)
+	}
+	// lag=+1 은 길이 10 → shifted 후 9 sample. NaN/Inf 없으므로 effectiveSamples = 9.
+	if got.SampleCount != 9 {
+		t.Errorf("SampleCount=%d want 9 (chosen lag +1 has 9 effective samples)", got.SampleCount)
 	}
 }
 

--- a/internal/correlation/pearson_test.go
+++ b/internal/correlation/pearson_test.go
@@ -1,0 +1,204 @@
+package correlation
+
+import (
+	"math"
+	"testing"
+)
+
+// samples 는 float 슬라이스로부터 timestamp 가 균등 간격인 Sample 슬라이스를 만든다. 테스트 의도가
+// Pearson 산출 수치 검증이라 실제 timestamp 값은 의미가 없고 0부터 1씩 증가시킨다.
+func samples(vs ...float64) []Sample {
+	out := make([]Sample, len(vs))
+	for i, v := range vs {
+		out[i] = Sample{TimestampMs: int64(i), Value: v}
+	}
+	return out
+}
+
+// approxEqual 은 부동소수점 오차를 흡수한 비교다. Pearson 산출에 부동소수점 누적 오차가 끼어 들어
+// 단순 == 비교는 false negative 를 만든다.
+func approxEqual(a, b, tol float64) bool {
+	return math.Abs(a-b) <= tol
+}
+
+// TestPearsonCorrelationPlusOne 은 두 시계열이 완벽 양 상관 (y = 2x + 3) 일 때 결과가 +1 임을 검증
+// 한다. Pearson 정의상 선형 변환은 +1 또는 -1 으로 떨어진다.
+func TestPearsonCorrelationPlusOne(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
+	b := TimeSeries{Samples: samples(5, 7, 9, 11, 13, 15, 17, 19, 21, 23)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q", status, StatusOK)
+	}
+	if !approxEqual(got, 1.0, 1e-9) {
+		t.Errorf("corr=%v want 1.0", got)
+	}
+}
+
+// TestPearsonCorrelationMinusOne 은 완벽 음 상관 (y = -x + c) 일 때 결과가 -1 임을 검증한다.
+func TestPearsonCorrelationMinusOne(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
+	b := TimeSeries{Samples: samples(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q", status, StatusOK)
+	}
+	if !approxEqual(got, -1.0, 1e-9) {
+		t.Errorf("corr=%v want -1.0", got)
+	}
+}
+
+// TestPearsonCorrelationZero 는 두 시계열이 무상관 (한쪽 일정 / 다른쪽 변동) 이지만 상수가 아닌
+// 입력에서 0에 근접한 결과를 내는지 검증한다. 완벽 0 무상관은 random sequence 에서만 일어나므로
+// 본 테스트는 직교 대칭 시퀀스 (1,-1,1,-1,...) 와 (1,2,3,4,5,4,3,2,1,...) 를 사용한다.
+func TestPearsonCorrelationZero(t *testing.T) {
+	a := TimeSeries{Samples: samples(-1, 1, -1, 1, -1, 1, -1, 1)}
+	b := TimeSeries{Samples: samples(1, 2, 3, 4, 4, 3, 2, 1)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q", status, StatusOK)
+	}
+	if math.Abs(got) > 0.1 {
+		t.Errorf("corr=%v want |corr| < 0.1 for orthogonal-ish sequences", got)
+	}
+}
+
+// TestPearsonCorrelationModerate 는 중간 정도 상관 (예: 0.5 부근) 을 검증한다. 입력은 base sequence
+// 에 일부 noise 를 더한 형태로 두 시계열이 비슷한 추세를 보이되 완벽 일치는 아니다.
+func TestPearsonCorrelationModerate(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
+	// b 는 a 와 같은 추세지만 매 timestamp 마다 다른 잡음을 추가해 완벽 +1 이 아닌 0.5-0.9 사이 상관
+	// 을 의도적으로 만든다.
+	b := TimeSeries{Samples: samples(3, 1, 4, 2, 6, 5, 9, 6, 8, 10)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q", status, StatusOK)
+	}
+	if got <= 0.3 || got >= 0.99 {
+		t.Errorf("corr=%v want moderate positive 0.3-0.99 (sanity for noisy ascending trend)", got)
+	}
+}
+
+// TestPearsonStddevZeroReturnsConstantStatus 는 한쪽 시계열이 상수 (분산 0) 일 때 NaN 대신 0 과
+// StatusSkippedConstant 를 반환하는지 검증한다. 본 가드가 빠지면 Pearson 분모 = 0 이라 NaN 이 emit
+// 되어 #51 exporter 가 잘못된 메트릭을 노출한다.
+func TestPearsonStddevZeroReturnsConstantStatus(t *testing.T) {
+	a := TimeSeries{Samples: samples(5, 5, 5, 5, 5, 5)} // 상수
+	b := TimeSeries{Samples: samples(1, 2, 3, 4, 5, 6)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusSkippedConstant {
+		t.Errorf("status=%q want %q", status, StatusSkippedConstant)
+	}
+	if got != 0 {
+		t.Errorf("corr=%v want 0 fallback", got)
+	}
+	if math.IsNaN(got) {
+		t.Errorf("corr is NaN; gate must replace it with 0")
+	}
+}
+
+// TestPearsonLowSamplesSkipped 는 입력 표본 수가 minSamples 미만이면 산출을 skip 하고 status 로
+// 표기하는지 검증한다.
+func TestPearsonLowSamplesSkipped(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 2)}
+	b := TimeSeries{Samples: samples(3, 4)}
+	got, status := Pearson(a, b, 5)
+	if status != StatusSkippedLowSamples {
+		t.Errorf("status=%q want %q", status, StatusSkippedLowSamples)
+	}
+	if got != 0 {
+		t.Errorf("corr=%v want 0", got)
+	}
+}
+
+// TestPearsonNilEmptyInputs 는 nil / empty 입력에서 panic 없이 low samples status 를 반환하는지
+// 검증한다. 0 길이 입력은 minSamples > 0 가드에 자연스럽게 걸린다.
+func TestPearsonNilEmptyInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b TimeSeries
+	}{
+		{"both_empty", TimeSeries{}, TimeSeries{}},
+		{"a_empty", TimeSeries{}, TimeSeries{Samples: samples(1, 2, 3, 4, 5)}},
+		{"b_empty", TimeSeries{Samples: samples(1, 2, 3, 4, 5)}, TimeSeries{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, status := Pearson(c.a, c.b, 3)
+			if status != StatusSkippedLowSamples {
+				t.Errorf("status=%q want %q", status, StatusSkippedLowSamples)
+			}
+			if got != 0 {
+				t.Errorf("corr=%v want 0", got)
+			}
+		})
+	}
+}
+
+// TestPearsonLengthMismatchTruncates 는 두 입력의 길이가 다를 때 짧은 쪽 기준으로 truncate 해 산출
+// 이 정상 수행되는지 검증한다.
+func TestPearsonLengthMismatchTruncates(t *testing.T) {
+	// a 는 6 개, b 는 4 개. 짧은 b 길이 4 로 truncate 되어 (1,2,3,4) 와 (1,2,3,4) 만 비교 → +1.
+	a := TimeSeries{Samples: samples(1, 2, 3, 4, 99, 100)}
+	b := TimeSeries{Samples: samples(1, 2, 3, 4)}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q (length mismatch should truncate, not skip)", status, StatusOK)
+	}
+	if !approxEqual(got, 1.0, 1e-9) {
+		t.Errorf("corr=%v want 1.0 (truncated arms are perfect linear)", got)
+	}
+}
+
+// TestPearsonNaNInfPairwiseRemoval 은 한쪽 시계열에 NaN / Inf 가 섞여 있을 때 해당 timestamp 만
+// 제거하고 나머지로 산출하는지 검증한다. Prometheus 가 가끔 데이터 공백 timestamp 에 NaN 을 emit
+// 하는 케이스에 대한 가드다.
+func TestPearsonNaNInfPairwiseRemoval(t *testing.T) {
+	// 두 시계열은 실제로 +1 상관이지만 a 의 2번째 sample 이 NaN, b 의 5번째가 +Inf 라 두 timestamp
+	// 가 pairwise 제거되어 (1,3,4,7) 와 (1,3,4,7) 만 비교 → 여전히 +1.
+	a := TimeSeries{Samples: []Sample{
+		{TimestampMs: 0, Value: 1},
+		{TimestampMs: 1, Value: math.NaN()},
+		{TimestampMs: 2, Value: 3},
+		{TimestampMs: 3, Value: 4},
+		{TimestampMs: 4, Value: 5},
+		{TimestampMs: 5, Value: 6},
+		{TimestampMs: 6, Value: 7},
+	}}
+	b := TimeSeries{Samples: []Sample{
+		{TimestampMs: 0, Value: 1},
+		{TimestampMs: 1, Value: 2},
+		{TimestampMs: 2, Value: 3},
+		{TimestampMs: 3, Value: 4},
+		{TimestampMs: 4, Value: math.Inf(1)},
+		{TimestampMs: 5, Value: 6},
+		{TimestampMs: 6, Value: 7},
+	}}
+	got, status := Pearson(a, b, 3)
+	if status != StatusOK {
+		t.Fatalf("status=%q want %q (NaN/Inf must be pairwise-removed, not poison the result)", status, StatusOK)
+	}
+	if !approxEqual(got, 1.0, 1e-9) {
+		t.Errorf("corr=%v want 1.0 (5 clean pairs all linear)", got)
+	}
+}
+
+// TestPearsonWithLagSelectsMaxAbs 는 lag 별 산출 후 최대 절대값 채택과 status 분류가 정상인지
+// 검증한다. 입력은 a 가 비단조 순열이고 b 는 a 의 한 step 지연 (b[t] = a[t-1]) 이라 cross-
+// correlation 관례 (lag k = corr(a[t], b[t+k])) 에서 lag=+1 일 때 a[t] = b[t+1] 이 완벽 일치해
+// 최대 상관, lag 0 / -1 에서는 비단조 순열이라 약한 상관을 보인다.
+func TestPearsonWithLagSelectsMaxAbs(t *testing.T) {
+	a := TimeSeries{Samples: samples(1, 5, 2, 8, 3, 7, 4, 6, 9, 10)}
+	// b[t] = a[t-1] (b[0] = 0 으로 채움). a 를 한 step 늦춘 형태라 a 가 b 를 한 step 앞선다.
+	b := TimeSeries{Samples: samples(0, 1, 5, 2, 8, 3, 7, 4, 6, 9)}
+	got := PearsonWithLag(a, b, []int{-1, 0, 1}, 3)
+	if got.Status != StatusOK {
+		t.Fatalf("status=%q want %q", got.Status, StatusOK)
+	}
+	if got.MaxAbsLag != 1 {
+		t.Errorf("MaxAbsLag=%d want 1 (a leads b by 1, so corr(a[t], b[t+1]) is maximal)", got.MaxAbsLag)
+	}
+	if !approxEqual(got.MaxAbsValue, 1.0, 1e-9) {
+		t.Errorf("MaxAbsValue=%v want ~1.0 at lag=+1", got.MaxAbsValue)
+	}
+}

--- a/internal/correlation/types.go
+++ b/internal/correlation/types.go
@@ -28,14 +28,18 @@ type TimeSeries struct {
 	Samples []Sample          `json:"samples"`
 }
 
-// PairKey는 상관계수 산출 대상 페어의 정체성을 표현하는 6필드 키다. src와 dst는 비대칭이며 운영자가
-// (X, Y) 결과와 (Y, X) 결과를 별도로 해석 가능하다.
+// PairKey는 상관계수 산출 대상 페어의 정체성을 표현하는 키다. src와 dst는 비대칭이며 운영자가
+// (X, Y) 결과와 (Y, X) 결과를 별도로 해석 가능하다. Pod UID 는 namespace + pod 이름이 재사용되는
+// StatefulSet 환경에서 재생성 전후의 시리즈를 구분하고 downstream consumer (#51 exporter) 가 UID
+// 라벨을 그대로 사용할 수 있게 한다.
 type PairKey struct {
 	SrcNamespace string `json:"src_namespace"`
 	SrcPod       string `json:"src_pod"`
+	SrcPodUID    string `json:"src_pod_uid"`
 	SrcMetric    string `json:"src_metric"`
 	DstNamespace string `json:"dst_namespace"`
 	DstPod       string `json:"dst_pod"`
+	DstPodUID    string `json:"dst_pod_uid"`
 	DstMetric    string `json:"dst_metric"`
 }
 

--- a/internal/correlation/types.go
+++ b/internal/correlation/types.go
@@ -4,10 +4,10 @@
 // 호출하는 형태가 본 이슈 #50의 expose 범위다. 주기적 자동화 (exporter / CronJob) 는 #51에서 다룬다.
 //
 // 본 패키지의 책임은 다음 네 가지다.
-//   1. Prometheus /api/v1/query_range로 다중 메트릭의 시계열을 가져오기 (fetcher)
-//   2. 노드 내 Pod 페어를 enumerate해 cross-product 폭발을 통제 (pair)
-//   3. 각 페어의 Pearson 상관계수를 lag 0 / +1 / -1 세 시점에서 산출 후 최대 절대값 채택 (pearson)
-//   4. 결과를 CorrelationResult slice로 반환 (orchestrator)
+//  1. Prometheus /api/v1/query_range로 다중 메트릭의 시계열을 가져오기 (fetcher)
+//  2. 노드 내 Pod 페어를 enumerate해 cross-product 폭발을 통제 (pair)
+//  3. 각 페어의 Pearson 상관계수를 lag 0 / +1 / -1 세 시점에서 산출 후 최대 절대값 채택 (pearson)
+//  4. 결과를 CorrelationResult slice로 반환 (orchestrator)
 //
 // 모든 산출은 호출 단위 stateless다. 시계열 buffer는 함수 scope 내 임시 자료로만 존재하고 GC된다.
 // 영구 저장소를 두지 않으며 cluster에 새 워크로드를 추가하지 않는다.

--- a/internal/correlation/types.go
+++ b/internal/correlation/types.go
@@ -1,0 +1,68 @@
+// Package correlation은 Prometheus query_range API로 가져온 netobs와 gpuobs 시계열의 Pearson 상관
+// 계수를 산출하는 stateless 라이브러리다. 데이터 수집 파이프라인 (DaemonSet agent → Prometheus
+// scrape → TSDB) 과 분리된 후행 분석 layer로 동작하며 운영자가 cmd/correlation-debug CLI로 1회성
+// 호출하는 형태가 본 이슈 #50의 expose 범위다. 주기적 자동화 (exporter / CronJob) 는 #51에서 다룬다.
+//
+// 본 패키지의 책임은 다음 네 가지다.
+//   1. Prometheus /api/v1/query_range로 다중 메트릭의 시계열을 가져오기 (fetcher)
+//   2. 노드 내 Pod 페어를 enumerate해 cross-product 폭발을 통제 (pair)
+//   3. 각 페어의 Pearson 상관계수를 lag 0 / +1 / -1 세 시점에서 산출 후 최대 절대값 채택 (pearson)
+//   4. 결과를 CorrelationResult slice로 반환 (orchestrator)
+//
+// 모든 산출은 호출 단위 stateless다. 시계열 buffer는 함수 scope 내 임시 자료로만 존재하고 GC된다.
+// 영구 저장소를 두지 않으며 cluster에 새 워크로드를 추가하지 않는다.
+package correlation
+
+// Sample은 단일 시점의 (timestamp, value) 쌍이다. timestamp는 Prometheus query_range가 반환하는
+// epoch milliseconds를 그대로 보존해 두 시계열의 timestamp 정렬을 비교 가능하게 한다.
+type Sample struct {
+	TimestampMs int64   `json:"timestamp_ms"`
+	Value       float64 `json:"value"`
+}
+
+// TimeSeries는 라벨 셋과 그 라벨에 해당하는 시계열 샘플들이다. Labels는 Prometheus가 반환한 원본
+// 라벨을 그대로 보존해 pair enumeration이 (node, src_namespace, src_pod, src_pod_uid) 같은 키로
+// 동일성을 판정할 수 있게 한다. Samples는 query_range step 단위로 정렬된 상태로 들어온다.
+type TimeSeries struct {
+	Labels  map[string]string `json:"labels"`
+	Samples []Sample          `json:"samples"`
+}
+
+// PairKey는 상관계수 산출 대상 페어의 정체성을 표현하는 6필드 키다. src와 dst는 비대칭이며 운영자가
+// (X, Y) 결과와 (Y, X) 결과를 별도로 해석 가능하다.
+type PairKey struct {
+	SrcNamespace string `json:"src_namespace"`
+	SrcPod       string `json:"src_pod"`
+	SrcMetric    string `json:"src_metric"`
+	DstNamespace string `json:"dst_namespace"`
+	DstPod       string `json:"dst_pod"`
+	DstMetric    string `json:"dst_metric"`
+}
+
+// Status는 단일 페어 산출 결과의 분류다. exporter (#51) 가 메트릭 라벨로 본 값을 그대로 사용 가능
+// 하도록 string enum으로 둔다.
+type Status string
+
+const (
+	// StatusOK는 유효한 표본 수와 분산으로 산출이 성공한 상태다.
+	StatusOK Status = "ok"
+	// StatusSkippedLowSamples는 입력 표본 수가 minSamples 미만이라 산출을 건너뛴 상태다. value는 0.
+	StatusSkippedLowSamples Status = "skipped_low_samples"
+	// StatusSkippedConstant는 두 시계열 중 하나라도 분산이 0 (상수 시계열) 이라 산출을 건너뛴 상태다.
+	// Pearson 정의상 분모가 0이 되어 NaN인데 본 패키지는 NaN 대신 0과 본 status를 반환한다.
+	StatusSkippedConstant Status = "skipped_constant"
+	// StatusPartial은 일부 lag에서는 산출됐고 일부 lag에서는 표본 부족으로 누락된 상태다. 최대 절대값
+	// 채택은 산출 가능한 lag 범위 내에서만 수행된다.
+	StatusPartial Status = "partial"
+)
+
+// CorrelationResult는 단일 페어의 lag별 상관계수와 최대 절대값 채택 결과를 담는다. #51 exporter가
+// 본 struct를 그대로 입력으로 받아 Prometheus 메트릭으로 변환 가능하도록 JSON tag 셋을 동결한다.
+type CorrelationResult struct {
+	Pair             PairKey         `json:"pair"`
+	CorrelationByLag map[int]float64 `json:"correlation_by_lag"`
+	MaxAbsLag        int             `json:"max_abs_lag"`
+	MaxAbsValue      float64         `json:"max_abs_value"`
+	SampleCount      int             `json:"sample_count"`
+	Status           Status          `json:"status"`
+}


### PR DESCRIPTION
## 요약

`internal/correlation/` placeholder를 실 구현으로 교체해 Prometheus 시계열을 가져와 노드 내 Pod 페어의 Pearson 상관계수를 산출하는 stateless 라이브러리를 도입한다. 본 시리즈의 #47 / #48 / #49 산출물 (`netobs_pod_bytes_total`, dst attribution, cause score recording rule) 을 입력으로 받아 운영자가 GPU 유휴 alert 발화 후 직전 1시간 윈도우에서 어떤 Pod 페어가 강한 상관을 보이는지 즉시 확인 가능하다. 데이터 수집 파이프라인과 분리된 후행 분석 layer로 동작하며 cluster에 새 워크로드를 추가하지 않는다. 주기적 자동화 (exporter) 는 #51에서 다룬다.

## 변경

`internal/correlation/`에 다음 6개 파일을 신설한다.

- `types.go`: `Sample`, `TimeSeries`, `PairKey`, `CorrelationResult`, `Status` 자료구조. JSON tag 명시적 부여로 #51 exporter가 schema를 그대로 입력으로 재사용 가능
- `pearson.go`: `Pearson`과 `PearsonWithLag` 두 함수. cross-correlation 관례의 lag k (`corr(a[t], b[t+k])`) 채택. NaN/Inf pairwise 제거, length mismatch truncate, 분산 0 fallback, 표본 부족 skip 가드 적용
- `pair.go`: `EnumeratePairs`가 동일 node 라벨 + self 제외 + (X,Y) (Y,X) 양방향 정책으로 페어 enumerate. cross-product N^2 폭발을 노드 단위 N_node^2로 통제
- `fetcher.go`: `PrometheusFetcher`가 `net/http`로 `/api/v1/query_range` 호출. `client_golang/api` 의존성을 도입하지 않아 외부 의존성을 표준 라이브러리로 한정. 응답 크기 100MB 상한으로 메모리 무제한 할당 차단
- `config.go`: `DefaultConfig`가 zero-config 산출 대상 query 11종 (#49 cause score 6개 + latency + node 자원 4개) 을 제공
- `correlator.go`: orchestration. 모든 query를 동일 start/end/step으로 fetch한 뒤 pair enumerate + Pearson 산출. 일부 query 실패는 부분 결과로 허용하고 모든 query 실패 시만 wrapped error 격상

`cmd/correlation-debug/`에 일회성 검증 CLI를 신설한다. 운영자가 `kubectl port-forward`로 Prometheus 접근 후 로컬에서 실행해 결과를 stdout JSON으로 받는다. cluster에 배포되지 않는다.

`Makefile`에 `build-correlation-debug` 타깃을 추가하고 placeholder `internal/correlation/doc.go`를 제거해 godoc은 `types.go` 상단으로 이전한다. `internal/correlation/README.md`를 placeholder에서 실 사용 가이드로 교체한다.

## 자체 코드 검토 반영

머지 전 코드 결함을 직접 검토해 다음 4건을 fix 커밋으로 반영했다.

- `Pearson` signature 를 `(float64, int, Status)` 로 확장해 NaN / Inf pairwise 제거 후 유효 표본 수를 반환. `PearsonWithLag` 가 MaxAbsLag 가 가리키는 lag 의 유효 표본 수를 `SampleCount` 에 보고하도록 정정 (기존은 모든 lag 중 max 추적 + NaN 제거 전 길이 사용으로 schema 의미 불일치). dead code 였던 `len(shiftedA) < len(shiftedB)` 분기도 제거
- `Correlator` 의 에러 조건 `len(all) == 0 && len(fetchErrors) > 0` 가 일부 query 가 성공해 빈 결과를 반환할 때도 \"all failed\" 로 잘못 분류하던 버그를 `len(fetchErrors) == len(queries)` 로 정정
- `fetcher.io.ReadAll` 에 `io.LimitReader` 로 100MB 상한 추가. Prometheus 가 비정상적으로 큰 응답을 보낼 때 메모리 폭발 차단
- `StatusPartial` 분류와 `SampleCount` 가 chosen lag 의 유효 표본 수임을 검증하는 단위 테스트 2건 추가

## 단위 테스트

총 22건.

- `pearson_test.go` 12건: 정상 4건 (+1, -1, 0, 중간값), edge case 6건 (stddev=0, 표본 부족, nil/empty, length mismatch, NaN/Inf pairwise 제거 + effectiveSamples assert, lag 최대 절대값 채택), 신규 2건 (`StatusPartial` 분류, `SampleCount` 가 chosen lag 기준)
- `pair_test.go` 5건: same-node 한정, self 제외, 양방향, same-pod cross-metric, empty node 라벨 제외
- `fetcher_test.go` 5건: matrix 응답 정상 파싱, 빈 결과, HTTP 5xx, 잘못된 JSON, Prometheus error response
- `correlator_test.go` 6건: happy path, empty input, partial fetch failure, all failure, default config 정합성, partial failure with empty results

`go test ./internal/correlation/...`, `go test -race`, `go vet` 모두 클린.

## 실 클러스터 검증

dev cluster의 Prometheus (kube-prometheus-stack v2.55) 에 직접 접근해 24h 윈도우 산출을 수행한 결과는 다음과 같다.

- 총 산출 페어: 834
- `status=ok`: 672건
- `status=skipped_constant`: 136건 (트래픽 없는 dev 상태의 일부 score가 sustained 0)
- `status=skipped_low_samples`: 26건 (lag shift 후 표본 부족)
- NaN 출현: **0건** (수용 조건 충족)
- `|max_abs_value| > 1`: **0건** (수용 조건 충족)
- `sample_count` 중앙값: 2880 (24h / 30s = 2880, lag=0 채택 일반)
- `sample_count` 최소: 1439 (대부분 lag=0 채택, 일부 lag=±1 채택 시 1 sample 감소)

수용 조건 \"실 클러스터의 24h 데이터로 호출되어 합리적 (NaN 없음, 절대값 1 이하) score를 반환\" 충족.

## 테스트 계획

- [x] `internal/correlation/` 단위 테스트 22건 통과
- [x] `go vet`, `go test -race` 클린
- [x] `make build-correlation-debug` 로 CLI binary 빌드 성공
- [x] CLI 를 실 cluster Prometheus 에 1h 윈도우로 호출 시 정상 JSON emit
- [x] 24h 윈도우 호출에서 NaN 0건, `|value| > 1` 0건 (수용 조건)
- [x] `SampleCount` 가 chosen lag 의 유효 표본 수를 정확히 반영
- [x] `pod:cpu_throttle_score:5m` 등 #49 cause score 입력이 default 로 잡혀 zero-config 동작
- [x] 응답 크기 100MB 상한으로 메모리 무제한 할당 차단
- [ ] #49 합성 시나리오 (`stress-ng` / `iperf3`) 와의 cross-validation: README 에 절차만 문서화, 자동화는 #52 머지 후 follow-up

## 비목표

- Top-N noisy neighbor 추출과 Prometheus exporter 노출: #51
- 부하 자동화: #52
- cross-node pair, lag 확장 (±N), `host_compute_stall_score` 의 결합 정밀화: follow-up

## 별도 follow-up 이슈로 분리

- exporter 형태 (#51 통합): 본 CLI 의 `CorrelationResult` JSON schema 를 라이브러리 입력으로 import 하는 형태로 자연 연결
- 합성 시나리오 자동화 (#52 통합): `stress-ng` / `iperf3` 워크로드 deploy + 결과 capture 의 자동화
- cross-node pair 분석
- lag 범위 확장과 동적 baseline
- `pod:host_compute_stall_score:5m` 의 단순 max 결합 정밀화 (#49 와 연계)
- `EnumeratePairs` 의 `make([]Pair, 0, len(items)*len(items))` 사전 할당 cost 감축 (대형 cluster 운영 시)
- `Pearson` 의 catastrophic cancellation 회피 (Kahan summation 등, 대형 byte rate 입력 시)

Closes #50
