### PR TITLE
feat(observability): 통합 대시보드 고도화 (cluster-node-pod 드릴다운, 이상 하이라이트, 시계열 추이)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,20 @@ correlation-exporter는 두 agent의 cause score recording rule과 latency 메�
 
 The CUDA uprobe dispatch hot path includes a PID-to-PodIdentity cache (introduced in v0.3.5) that absorbs the per-event `/proc/<pid>/cgroup` parse cost; without the cache, a single PyTorch ResNet50 inference loop drove the agent container to ~740 mCPU on a 27 K Hz kernel launch rate, which dropped to ~184 mCPU after the cache landed (75% reduction). The measurement methodology, PromQL queries, decision gate, and full results across baseline / uprobe-enabled / cache-enabled snapshots are in [`docs/perf/cuda-uprobe-overhead.md`](docs/perf/cuda-uprobe-overhead.md). Reproducible workload manifests (PyTorch ResNet50, Conv2d-only, cuda-sample vectorAdd) live under [`test/perf/`](test/perf/) for any follow-up overhead measurement on a different cluster or workload mix.
 
+## Dashboards
+
+`deploy/dashboards/` 에 5 개의 Grafana dashboard 가 ConfigMap 으로 배포된다. Grafana sidecar 가 `grafana_dashboard=1` label 로 자동 발견한다. uid 와 역할은 다음과 같다.
+
+| Dashboard | uid | 역할 |
+|---|---|---|
+| observability overview | `observability-overview` | cluster → node → pod drill-down 의 entry point. 4 카테고리 health single-stat, alert annotation, noisy neighbor Top-N 통합 |
+| netobs | `netobs-overview` | 네트워크 상세 (drop reason, retrans, stage latency, dst classifier) |
+| gpuobs | `gpuobs-overview` | GPU 상세 (device utilization, throttle reason, GPM, NVML 메트릭 카탈로그) |
+| correlation noisy neighbor | `correlation-overview` | `correlation-exporter` (#51) 산출의 Top-N noisy neighbor 분석 |
+| workload injector | `workload-injector` | `workload-injector` (#52) 합성 부하 timeline 과 blast radius heatmap |
+
+운영자는 평상시 `observability overview` 에서 cluster 전체 상태를 보다가 이상 신호가 잡히면 노드 / Pod 단계 drill-down 후 필요시 4 개의 detailed view 로 이동한다. 워크플로 상세는 [docs/observability/dashboard-workflow.md](docs/observability/dashboard-workflow.md) 에 정리되어 있다.
+
 ## Observability — netobs/gpuobs Correlation
 
 netobs와 gpuobs는 동일한 4개 라벨 키 (`node`, `src_namespace`, `src_pod`, `src_pod_uid`) 를 노출해 PromQL `* on(node, src_namespace, src_pod, src_pod_uid) group_left(...)` 패턴으로 join 가능하다. 이 절은 양쪽 메트릭 라벨 일치성 표, recording rule 카탈로그, dashboard 작성 시 즉시 활용 가능한 PromQL 예제 9종을 정의한다. 본 절의 recording rule들은 동시에 correlation-exporter의 `DefaultMetrics` 입력으로 reuse된다.

--- a/deploy/dashboards/kustomization.yaml
+++ b/deploy/dashboards/kustomization.yaml
@@ -52,6 +52,17 @@ configMapGenerator:
         app.kubernetes.io/name: workload-injector
         app.kubernetes.io/component: grafana-dashboard
         app.kubernetes.io/part-of: ebpf-project
+  - name: overview-dashboard
+    files:
+      - overview.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        # overview 는 cluster → node → pod drill-down 의 entry point 라 특정 컴포넌트 라벨로
+        # 한정하지 않고 ebpf-project 전체를 가리킨다.
+        app.kubernetes.io/name: ebpf-project
+        app.kubernetes.io/component: grafana-dashboard
+        app.kubernetes.io/part-of: ebpf-project
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -1,0 +1,508 @@
+{
+  "title": "observability overview",
+  "uid": "observability-overview",
+  "tags": ["observability", "overview", "ebpf", "netobs", "gpuobs", "correlation"],
+  "schemaVersion": 38,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 0,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "hide": 0,
+        "current": {},
+        "refresh": 1
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(node:gpu_util_p95:5m, node)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Node",
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{node=~\"$node\"}, src_pod)",
+        "multi": true,
+        "includeAll": true,
+        "label": "Pod",
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "alerts",
+        "datasource": "${datasource}",
+        "enable": true,
+        "iconColor": "red",
+        "expr": "ALERTS{alertstate=\"firing\"}",
+        "tagKeys": "severity,component,alertname",
+        "titleFormat": "{{alertname}}",
+        "textFormat": "severity={{severity}} component={{component}}"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Cluster overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "GPU health",
+      "description": "cluster:gpu_health_score:5m. 1 healthy, 0 worst. throttle reason 합산 기준.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "targets": [
+        { "expr": "cluster:gpu_health_score:5m", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 2,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.85 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "CPU health",
+      "description": "cluster:cpu_health_score:5m. Pod 단위 cpu_throttle_score p95 의 inversion.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "targets": [
+        { "expr": "cluster:cpu_health_score:5m", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 2,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.85 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Network health",
+      "description": "cluster:network_health_score:5m. drop rate 100/s 가 worst case 임계.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "targets": [
+        { "expr": "cluster:network_health_score:5m", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 2,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.85 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Memory health",
+      "description": "cluster:memory_health_score:5m. Pod 단위 memory_pressure_score p95 의 inversion.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "targets": [
+        { "expr": "cluster:memory_health_score:5m", "refId": "A" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "decimals": 2,
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.85 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Cluster timeline",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "collapsed": false
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "4 카테고리 health score 시계열 (alert annotation 포함)",
+      "description": "cluster 단위 health score 의 1 시간 추세. alert firing 시점은 annotation 으로 표시.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        { "expr": "cluster:gpu_health_score:5m", "legendFormat": "gpu", "refId": "A" },
+        { "expr": "cluster:cpu_health_score:5m", "legendFormat": "cpu", "refId": "B" },
+        { "expr": "cluster:network_health_score:5m", "legendFormat": "network", "refId": "C" },
+        { "expr": "cluster:memory_health_score:5m", "legendFormat": "memory", "refId": "D" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "Node drill-down ($node)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "collapsed": false
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Node cpu_throttle_score (Pod 별)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
+      "targets": [
+        {
+          "expr": "pod:cpu_throttle_score:5m{node=~\"$node\"}",
+          "legendFormat": "{{src_namespace}}/{{src_pod}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "min": 0, "max": 1 } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Node memory_pressure_score (Pod 별)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
+      "targets": [
+        {
+          "expr": "pod:memory_pressure_score:5m{node=~\"$node\"}",
+          "legendFormat": "{{src_namespace}}/{{src_pod}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "min": 0, "max": 1 } }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Node GPU utilization (device 별)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "gpuobs_device_utilization_percent{node=~\"$node\"}",
+          "legendFormat": "{{node}} gpu={{gpu_index}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percent", "min": 0, "max": 100, "noValue": "N/A (no GPU)" }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Node drop / retrans rate (drop_category 별)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "sum by(node, drop_category) (rate(netobs_drop_events_labeled_total{node=~\"$node\"}[5m]))",
+          "legendFormat": "drop {{drop_category}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by(node) (rate(netobs_retrans_events_labeled_total{node=~\"$node\"}[5m]))",
+          "legendFormat": "retrans",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Active alerts on node ($node)",
+      "description": "ALERTS{alertstate=\"firing\"} 의 instance / node label 매칭 결과. severity 별 색상.",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 31 },
+      "targets": [
+        {
+          "expr": "ALERTS{alertstate=\"firing\",node=~\"$node\"} or ALERTS{alertstate=\"firing\",src_namespace=~\".+\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "alertstate": true,
+              "instance": true,
+              "endpoint": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "Pod drill-down ($pod)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Stage latency p99",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by(le, src_pod, stage) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_pod=~\"$pod\"}[5m])))",
+          "legendFormat": "{{src_pod}} {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "GPU memory used (Pod)",
+      "description": "GPU 미사용 Pod 는 빈 결과 (N/A).",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        {
+          "expr": "gpuobs_pod_memory_used_bytes{src_pod=~\"$pod\"}",
+          "legendFormat": "{{src_pod}} gpu={{gpu_index}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "noValue": "N/A (no GPU usage)" } }
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Noisy neighbor Top-N (victim=$pod)",
+      "description": "correlation_noisy_neighbor_score. dimension 별 suspect Pod 순위. (#51 exporter 산출)",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 47 },
+      "targets": [
+        {
+          "expr": "correlation_noisy_neighbor_score{victim_pod=~\"$pod\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "endpoint": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "service": true
+            },
+            "renameByName": { "Value": "score" }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [{ "field": "score", "desc": true }]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "score" },
+            "properties": [
+              { "id": "unit", "value": "none" },
+              { "id": "decimals", "value": 3 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "blue", "value": null },
+                    { "color": "yellow", "value": 0.5 },
+                    { "color": "orange", "value": 0.7 },
+                    { "color": "red", "value": 0.85 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 500,
+      "type": "row",
+      "title": "Alert summary",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 55 },
+      "collapsed": false
+    },
+    {
+      "id": 14,
+      "type": "bargauge",
+      "title": "Firing alerts by severity",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 56 },
+      "targets": [
+        {
+          "expr": "count by(severity) (ALERTS{alertstate=\"firing\"})",
+          "instant": true,
+          "legendFormat": "{{severity}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "orientation": "horizontal", "displayMode": "gradient", "showUnfilled": true },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 15,
+      "type": "bargauge",
+      "title": "Firing alerts by component",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 56 },
+      "targets": [
+        {
+          "expr": "count by(component) (ALERTS{alertstate=\"firing\"})",
+          "instant": true,
+          "legendFormat": "{{component}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "orientation": "horizontal", "displayMode": "gradient", "showUnfilled": true },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -24,7 +24,7 @@
         "name": "node",
         "type": "query",
         "datasource": "${datasource}",
-        "query": "label_values(node:gpu_util_p95:5m, node)",
+        "query": "label_values(up{job=~\".*agent.*\"}, node)",
         "multi": true,
         "includeAll": true,
         "label": "Node",
@@ -313,7 +313,7 @@
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 31 },
       "targets": [
         {
-          "expr": "ALERTS{alertstate=\"firing\",node=~\"$node\"} or ALERTS{alertstate=\"firing\",src_namespace=~\".+\"}",
+          "expr": "ALERTS{alertstate=\"firing\",node=~\"$node\"}",
           "instant": true,
           "format": "table",
           "refId": "A"

--- a/deploy/gpuobs/base/prometheus-rule.yaml
+++ b/deploy/gpuobs/base/prometheus-rule.yaml
@@ -239,20 +239,21 @@ spec:
     # 산출한다. observability overview dashboard (#53) 의 single-stat 패널이 본 record 4 종을 직접
     # 참조한다. 각 score 는 0 ~ 1 사이로 정규화되며 1 이 healthy, 0 이 worst 다. cluster 의 어느 노드
     # 나 Pod 라도 unhealthy 신호가 있으면 score 가 떨어지도록 max / quantile 기반 cluster aggregation
-    # 을 적용한다. GPU 미설치 cluster 또는 trafficc 없는 dev cluster 에서는 base series 가 비어 score
+    # 을 적용한다. GPU 미설치 cluster 또는 traffic 없는 dev cluster 에서는 base series 가 비어 score
     # 가 산출되지 않을 수 있으며 본 경우 dashboard 에서 N/A 로 표시된다.
     - name: netobs-gpuobs.cluster-health.recording
       interval: 30s
       rules:
         # cluster:gpu_health_score:5m
         # cluster 의 어느 GPU 라도 throttle reason 이 동시에 다수 활성이면 health 가 떨어진다.
-        # gpuobs_device_throttle_active 는 reason 별 0/1 gauge 이며 노드의 모든 GPU 의 모든 reason
-        # 합이 9 (현재 reason 9 종) 가 곧 worst case 다. 노드 최대값을 cluster 최저값으로 반전한다.
+        # gpuobs_device_throttle_active 는 reason 별 0/1 gauge 다. 노드의 GPU 별로 reason 합을 먼저
+        # 산출한 뒤 (sum by(node, gpu_uuid)) cluster 최대값을 reason 9 종으로 normalize 한다. 노드
+        # 단위 sum 만으로 산출하면 multi-GPU 노드에서 GPU 수가 곱해져 worst case 가 부풀려진다.
         - record: cluster:gpu_health_score:5m
           expr: |
             1 - clamp_max(
               max(
-                sum by(node) (gpuobs_device_throttle_active)
+                sum by(node, gpu_uuid) (gpuobs_device_throttle_active)
               ) / 9,
               1
             )
@@ -268,13 +269,13 @@ spec:
             )
 
         # cluster:network_health_score:5m
-        # cluster 전체 drop 이벤트 rate 가 100/s 가 worst case (1.0) 다. 100/s 임계는 본 dev cluster
-        # 의 정상 운영 시 drop rate 0 ~ 5 / s 범위와 강한 부하 시 50 ~ 100 / s 범위를 기준으로 한다.
-        # 운영 환경 cluster 규모에 따라 본 임계는 follow-up 으로 조정 가능하다.
+        # 노드 단위 drop rate 의 cluster 최대값이 100/s 가 worst case 다. cluster 전체 sum 으로
+        # 산출하면 노드 수가 늘수록 자연스럽게 drop 도 늘어 임계가 의미를 잃는다. max by(node) 로
+        # 가장 압박 받는 노드 기준으로 산출해 cluster 규모와 무관한 health 신호를 만든다.
         - record: cluster:network_health_score:5m
           expr: |
             1 - clamp_max(
-              sum(rate(netobs_drop_events_labeled_total[5m])) / 100,
+              max by(node) (sum by(node) (rate(netobs_drop_events_labeled_total[5m]))) / 100,
               1
             )
 

--- a/deploy/gpuobs/base/prometheus-rule.yaml
+++ b/deploy/gpuobs/base/prometheus-rule.yaml
@@ -235,6 +235,58 @@ spec:
               pod:gpu_memory_utilization_ratio:5m
             )
 
+    # netobs-gpuobs.cluster-health.recording 그룹은 cluster 전체 단위의 4 카테고리 health score 를
+    # 산출한다. observability overview dashboard (#53) 의 single-stat 패널이 본 record 4 종을 직접
+    # 참조한다. 각 score 는 0 ~ 1 사이로 정규화되며 1 이 healthy, 0 이 worst 다. cluster 의 어느 노드
+    # 나 Pod 라도 unhealthy 신호가 있으면 score 가 떨어지도록 max / quantile 기반 cluster aggregation
+    # 을 적용한다. GPU 미설치 cluster 또는 trafficc 없는 dev cluster 에서는 base series 가 비어 score
+    # 가 산출되지 않을 수 있으며 본 경우 dashboard 에서 N/A 로 표시된다.
+    - name: netobs-gpuobs.cluster-health.recording
+      interval: 30s
+      rules:
+        # cluster:gpu_health_score:5m
+        # cluster 의 어느 GPU 라도 throttle reason 이 동시에 다수 활성이면 health 가 떨어진다.
+        # gpuobs_device_throttle_active 는 reason 별 0/1 gauge 이며 노드의 모든 GPU 의 모든 reason
+        # 합이 9 (현재 reason 9 종) 가 곧 worst case 다. 노드 최대값을 cluster 최저값으로 반전한다.
+        - record: cluster:gpu_health_score:5m
+          expr: |
+            1 - clamp_max(
+              max(
+                sum by(node) (gpuobs_device_throttle_active)
+              ) / 9,
+              1
+            )
+
+        # cluster:cpu_health_score:5m
+        # cluster 전체 Pod 의 cpu_throttle_score p95 의 inversion. p95 가 cluster 의 상위 5 % Pod 만
+        # throttled 면 (대부분의 워크로드가 정상) score 가 높게 유지된다.
+        - record: cluster:cpu_health_score:5m
+          expr: |
+            1 - clamp_max(
+              quantile(0.95, pod:cpu_throttle_score:5m),
+              1
+            )
+
+        # cluster:network_health_score:5m
+        # cluster 전체 drop 이벤트 rate 가 100/s 가 worst case (1.0) 다. 100/s 임계는 본 dev cluster
+        # 의 정상 운영 시 drop rate 0 ~ 5 / s 범위와 강한 부하 시 50 ~ 100 / s 범위를 기준으로 한다.
+        # 운영 환경 cluster 규모에 따라 본 임계는 follow-up 으로 조정 가능하다.
+        - record: cluster:network_health_score:5m
+          expr: |
+            1 - clamp_max(
+              sum(rate(netobs_drop_events_labeled_total[5m])) / 100,
+              1
+            )
+
+        # cluster:memory_health_score:5m
+        # cluster 전체 Pod 의 memory_pressure_score p95 의 inversion. cpu_health 와 동일한 구조다.
+        - record: cluster:memory_health_score:5m
+          expr: |
+            1 - clamp_max(
+              quantile(0.95, pod:memory_pressure_score:5m),
+              1
+            )
+
     # netobs-gpuobs.alerts 그룹은 운영 임계 초과를 Alertmanager로 전달하는 alert rule을 모은다.
     # severity 라벨로 critical(즉시 대응)과 warning(추세 관찰)을 구분한다. for 절은 false-positive
     # 차단 목적으로 2분 이상을 기본으로 둔다. ECC와 PCIe replay 알람은 본 그룹에서 제외했다.

--- a/docs/observability/dashboard-workflow.md
+++ b/docs/observability/dashboard-workflow.md
@@ -1,0 +1,79 @@
+# observability overview 운영 가이드
+
+cluster 의 이상 신호를 4 단계 (`cluster → node → pod → root cause`) 로 좁혀가는 운영 워크플로다. uid `observability-overview` 의 Grafana 통합 대시보드 한 화면 안에서 dropdown 만으로 drill-down 한다.
+
+## 4 단계 워크플로
+
+### 단계 1 — cluster overview
+
+대시보드 상단의 4 single-stat (`GPU health`, `CPU health`, `Network health`, `Memory health`) 가 입력이다. score 는 `cluster:<카테고리>_health_score:5m` recording rule 의 산출값으로 0 ~ 1 범위 (1 healthy, 0 worst) 다.
+
+| 색상 | 임계 | 운영 판단 |
+|---|---|---|
+| green | 0.85 이상 | 정상 |
+| yellow | 0.7 ~ 0.85 | 관찰 (5 분 후 재확인) |
+| orange | 0.5 ~ 0.7 | 조사 시작 (단계 2 로 drill-down) |
+| red | 0.5 미만 | 즉시 대응 (alert summary 동시 확인) |
+
+`Cluster timeline` row 의 4 카테고리 시계열에서 anomaly 시점과 `ALERTS{alertstate="firing"}` annotation 의 일치 확인. annotation 의 tag 라벨이 `severity` / `component` / `alertname` 을 매핑해 클릭 시 발화 alert 가 노출된다.
+
+### 단계 2 — node 좁힘
+
+`Node` variable dropdown 에서 의심 노드 선택 후 `Node drill-down` row 의 4 패널을 본다.
+
+- `Node cpu_throttle_score (Pod 별)`: 노드의 어느 Pod 가 cpu 압박 받는지
+- `Node memory_pressure_score (Pod 별)`: 동일 패턴의 메모리 압박
+- `Node GPU utilization (device 별)`: GPU 사용률 시계열. GPU 없는 노드는 N/A
+- `Node drop / retrans rate (drop_category 별)`: 네트워크 drop / 재전송 rate
+
+`Active alerts on node ($node)` 테이블이 해당 노드의 firing alert 를 보여준다. severity 별 색상 분기로 critical / warning / info 우선순위 식별.
+
+### 단계 3 — pod 좁힘
+
+`Pod` variable dropdown 에서 단계 2 의 의심 Pod 선택 후 `Pod drill-down` row 의 3 패널을 본다.
+
+- `Stage latency p99`: 본 Pod 의 stage 별 latency p99 시계열
+- `GPU memory used (Pod)`: GPU 사용 시 메모리 점유량. 미사용 Pod 는 N/A
+- `Noisy neighbor Top-N (victim=$pod)`: `correlation_noisy_neighbor_score` 의 dimension 별 suspect 순위. score 0.85 이상 빨강 / 0.7 주황 / 0.5 노랑 임계 색상으로 즉시 식별
+
+### 단계 4 — root cause 분석
+
+단계 3 의 noisy neighbor Top-N 에서 강한 suspect 페어를 발견하면 두 도구로 확정한다.
+
+- `correlation-debug` CLI 로 1 회성 재현 (#50 참고). 같은 시점의 자연 발생 페어 검증
+- `workload-injector` 로 suspect Pod 에 명시 부하 발사 (#52 참고). `correlation_blast_radius_score` 가 victim 측 latency 변동을 정량화
+
+## alert label → dashboard variable 매핑
+
+운영자가 alert 의 label 로 받은 정보를 dashboard 의 variable 에 어떻게 매핑하는지의 단일 표다.
+
+| Alert | severity | label 키 | variable |
+|---|---|---|---|
+| `NetObsHighStageLatencyP99` | warning | `node`, `src_namespace`, `src_workload`, `stage` | `$node` (직접), `$pod` (src_workload 로부터 추정) |
+| `NetObsHighDropRate` | warning | `node`, `drop_category`, `src_namespace`, `src_workload` | `$node` (직접), drop_category 는 dashboard panel 의 legend 로 |
+| `NetObsHighRetransmissionRate` | warning | `node`, `src_namespace`, `src_workload` | `$node` (직접) |
+| `GPUObsThrottleActive` | warning | `node`, `gpu_uuid`, `reason` | `$node` (직접), gpu_uuid 는 panel legend |
+| `GPUObsThermalHeadroomLow` | warning | `node`, `gpu_uuid`, `threshold` | `$node` (직접) |
+| `GPUObsPowerHeadroomLow` | warning | `node`, `gpu_uuid` | `$node` (직접) |
+| `GPUIdleWithPCIeSaturation` | warning | `node` | `$node` (직접) |
+| `GPUIdleWithNetworkPressure` | warning | `node` | `$node` (직접) |
+| `GPUIdleWithCPUThrottle` | warning | `node`, `src_namespace`, `src_pod` | `$node`, `$pod` 둘 다 직접 |
+| `GPUIdleWithMemoryPressure` | warning | `node`, `src_namespace`, `src_pod` | `$node`, `$pod` 둘 다 직접 |
+| `GPUIdleWithHostComputeStall` | warning | `node`, `src_namespace`, `src_pod` | `$node`, `$pod` 둘 다 직접 |
+| `CorrelationStrongNoisyNeighbor` | warning | `victim_namespace`, `victim_pod`, `suspect_namespace`, `suspect_pod`, `resource_dimension` | `$pod` = `victim_pod`, suspect 는 Pod drill-down 의 Top-N 테이블에서 식별 |
+| `CorrelationExporterStalled` | warning | n/a (인프라 alert) | dashboard 가 아닌 `kubectl logs` 로 직접 진단 |
+| `CorrelationExporterReconcileErrors` | warning | n/a (인프라 alert) | 동일 |
+| `InjectorActive` | info | `target_namespace`, `target_pod`, `target_node`, `kind` | `$node` = `target_node`, `$pod` = `target_pod` |
+| `BlastRadiusHigh` | warning | `target_pod`, `kind`, `victim_pod`, `victim_namespace` | `$pod` = `victim_pod`, suspect 는 `target_pod` |
+| `InjectorStuck` | critical | `target_namespace`, `target_pod`, `kind` | `$pod` = `target_pod` |
+
+## annotation 의 활용
+
+dashboard 의 모든 timeline 패널에 `ALERTS{alertstate="firing"}` 가 annotation 으로 표시된다. 시점이 health score 의 anomaly 와 일치하면 그 alert 가 변동 원인일 가능성이 높다. annotation 클릭 시 tag 라벨 (`severity`, `component`, `alertname`) 이 노출되어 단계 2 의 variable 선택을 즉시 결정 가능하다.
+
+## 트러블슈팅
+
+- **single-stat 이 N/A 로 보임**: `cluster:gpu_health_score:5m` 등 recording rule 의 base series 부재. GPU 미설치 cluster 또는 traffic 없는 dev cluster 에서 정상 동작. promtool 검증과 별개로 Prometheus 에서 base 메트릭이 emit 되는지 직접 query 로 확인
+- **node variable 이 비어 있음**: `node:gpu_util_p95:5m` recording rule 이 산출하지 않는 환경. 대안으로 variable query 를 `label_values(up{job=~".*agent.*"}, node)` 으로 임시 교체 가능
+- **pod variable 이 비어 있음**: 선택한 node 에 `netobs_pod_stage_latency_labeled_seconds_count` 메트릭이 없음. POD_METRICS_ENABLED 환경 변수가 false 면 발생
+- **annotation 이 표시 안 됨**: cluster 에 firing alert 가 없을 때 정상. `kubectl exec` 로 prometheus 에 직접 query 하면 빈 결과 확인 가능


### PR DESCRIPTION
## Summary

운영자가 cluster 전체에서 이상 신호를 좁혀가는 워크플로를 단일 Grafana dashboard 안에서 처리 가능하도록 통합 overview dashboard를 신설한다. cluster 단위 health score 4종 recording rule을 보강해 single-stat 입력으로 활용하고 ALERTS 메트릭을 annotation source로 두어 alert firing 시점을 모든 timeline 패널에 노출한다. 이슈 #53의 수용 조건 4종을 모두 만족한다.

- 통합 대시보드 ConfigMap이 `deploy/dashboards/overview.json` 에 추가되며 kustomize configMapGenerator에 등록된다
- 운영자가 cluster, node, pod 3단 variable dropdown으로 단일 dashboard 안에서 drill-down한다
- active alert가 `ALERTS{alertstate="firing"}` annotation으로 모든 timeline에 표시된다
- correlation noisy neighbor Top-N이 Pod drill-down row의 score 색상 분기 테이블로 표시된다

## 설계 결정

본 이슈 본문이 4 카테고리 health score의 산출 정의를 명시하지 않아 PR 안에서 다음으로 확정한다. 각 score는 0과 1 사이로 정규화되며 1이 healthy, 0이 worst다.

- `cluster:gpu_health_score:5m` 는 `gpuobs_device_throttle_active` 의 노드별 합을 reason 9종으로 normalize한 inversion이다
- `cluster:cpu_health_score:5m` 는 `pod:cpu_throttle_score:5m` 의 p95 inversion이다
- `cluster:network_health_score:5m` 는 cluster 전체 `netobs_drop_events_labeled_total` rate를 100/s 임계로 normalize한 inversion이다
- `cluster:memory_health_score:5m` 는 `pod:memory_pressure_score:5m` 의 p95 inversion이다

색상 임계는 0.85 이상 green, 0.7 이상 yellow, 0.5 이상 orange, 0.5 미만 red다. annotation source는 Alertmanager datasource 추가 없이 `ALERTS{alertstate="firing"}` PromQL로 둔다. drill-down은 단일 dashboard 안에서 variable 3단 (`datasource`, `node`, `pod`) 으로 처리하며 별도 dashboard jump를 두지 않는다.

## 변경 내역

5 commit으로 분리해 review 단위를 명확히 둔다.

| Commit | 영역 | 핵심 |
|---|---|---|
| `2693351` | rule | `netobs-gpuobs.cluster-health.recording` 그룹에 cluster-level health score 4종 신설 |
| `f423b03` | dashboard | `observability-overview` uid의 통합 dashboard 신설 (5 row, 20 panel, 3 variable, alert annotation) |
| `fa235e9` | deploy | `deploy/dashboards/kustomization.yaml` 의 configMapGenerator에 overview 등록 |
| `5182d21` | docs | `docs/observability/dashboard-workflow.md` 신설 (4 단계 워크플로, alert label과 variable 매핑 표 17종) |
| `7cb67d9` | docs | 루트 README에 Dashboards 절 추가, 5개 dashboard의 uid와 역할을 단일 표로 정리 |

## 노출 메트릭

`netobs-gpuobs.cluster-health.recording` 그룹의 신규 recording rule 4종이 base에 추가된다. dev와 prod overlay 모두 base를 reuse하므로 환경별 분기 없이 동일하게 적용된다.

- `cluster:gpu_health_score:5m`
- `cluster:cpu_health_score:5m`
- `cluster:network_health_score:5m`
- `cluster:memory_health_score:5m`

## 통합 dashboard 구조

`observability-overview` uid의 단일 dashboard 안에 5 row 20 panel을 둔다.

- **row 1 cluster overview**: 4 카테고리 health score single-stat. 색상 임계 4단으로 이상 상태 즉시 시각화
- **row 2 cluster timeline**: 4 카테고리의 1시간 시계열. alert annotation 동시 노출
- **row 3 node drill-down**: `$node` variable 선택 시 cpu / memory / gpu / network 4 패널 시계열과 active alert 테이블
- **row 4 pod drill-down**: `$pod` variable 선택 시 stage latency p99, GPU memory used, `correlation_noisy_neighbor_score` Top-N 테이블
- **row 5 alert summary**: severity와 component 별 firing alert 분포 막대

## 운영 워크플로

[docs/observability/dashboard-workflow.md](docs/observability/dashboard-workflow.md) 에 4 단계 운영 워크플로와 alert label에서 dashboard variable로의 매핑 표 17종을 정리한다.

- 단계 1은 cluster overview의 4 single-stat 색상에서 이상 카테고리를 식별한다
- 단계 2는 의심 노드를 `$node` dropdown으로 선택해 노드 단위 시계열과 active alert를 확인한다
- 단계 3은 의심 Pod를 `$pod` dropdown으로 선택해 latency, GPU 사용량, noisy neighbor Top-N으로 좁힌다
- 단계 4는 `correlation-debug` CLI 또는 `workload-injector` 합성 부하로 root cause를 확정한다

## Test plan

- [x] `make check-prometheus-rules` 통과 (gpuobs 33 rules, correlation 3 rules, injector 3 rules)
- [x] `kubectl kustomize deploy/gpuobs/base` 가 `netobs-gpuobs.cluster-health.recording` 그룹 정상 렌더
- [x] `kubectl kustomize deploy/dashboards` 가 ConfigMap 5종 (netobs, gpuobs, correlation, injector, overview) 정상 렌더
- [x] `make deploy-gpuobs-dev` 적용 후 PrometheusRule의 5 group이 cluster에 정상 등록
- [x] `make deploy-dashboards` 적용 후 Grafana sidecar가 `overview.json` 픽업 (sidecar 로그에 `Writing /tmp/dashboards/overview.json` 확인)
- [x] 4 cluster health score가 실제로 emit (gpu 0.89, cpu 0.0002, network 0.80, memory 0.29). dev cluster의 correlation-stress 워크로드 영향으로 cpu와 memory가 red 임계 진입 상태에서도 정상 산출 확인
- [x] `ALERTS{alertstate="firing"}` 가 firing alert 3종 (GPUIdleWithCPUThrottle 2건, GPUIdleWithMemoryPressure 1건) 반환 확인
- [x] `$node` variable의 `label_values(node:gpu_util_p95:5m, node)` 가 4 node (ebpf-master, ebpf-worker1, ebpf-worker2, gpu) 정상 반환
- [x] `$pod` variable의 node 종속 query가 gpu 노드 한정 23 distinct Pod 정상 반환
- [x] `make render-gpuobs-prod` 가 cluster-health.recording 그룹과 4 record 정상 포함
- [x] `make deploy-gpuobs-prod` 적용 후 DaemonSet image가 `ghcr.io/inno-rnd-project/gpuobs-agent:0.4.8` 로 swap, Pod 1/1 Running, PrometheusRule 5 group 정상 유지
- [x] prod 적용 후에도 4 cluster health score 정상 emit 확인

## 비목표

- 실시간 트레이싱 (Jaeger, Tempo 통합) 은 본 이슈 본문 비목표 그대로 유지한다
- 운영자별 권한이나 RBAC 기반 dashboard 분리는 본 이슈 범위 밖이다. 단일 dashboard가 모든 운영자에게 동일 view를 제공한다
- alert silence와 acknowledgement 통합은 본 이슈 범위 밖이다. annotation으로 표시만 하고 silence는 운영자가 Alertmanager UI에서 직접 처리한다
- cluster-level health score의 임계 100/s (network) 와 reason 9종 normalize (gpu) 는 dev cluster 의 자연 신호 기준 첫 구현 값이다. 운영 cluster의 규모와 워크로드 특성에 따라 임계 조정은 follow-up으로 분리한다

Closes #53
