### PR TITLE
feat(netobs): skb_drop의 5-tuple flow context와 burst 패턴 분류

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The CI workflow [`integration.yml`](.github/workflows/integration.yml) runs the 
 | `POD_METRICS_ENABLED` | `-pod-metrics` | `true` | Emit per-pod-instance metrics (`netobs_pod_stage_*`); disable on large clusters to cap Prometheus cardinality |
 | `POD_FLOW_DST_ENABLED` | `-pod-flow-dst` | `true` | Emit `dst_namespace`/`dst_workload` labels on stage/drop/retrans metrics; disable to keep pre-flow-dst cardinality |
 | `POD_FLOW_DST_UID_ALLOW_NAMESPACES` | `-pod-flow-dst-uid-allow-namespaces` | *(empty)* | Comma-separated namespace allow-list whose Pods receive `dst_pod_uid` labels; empty disables UID emit cluster-wide. Each entry must match RFC1123 DNS label (lowercase alphanumeric + hyphen, 1-63 chars) and is fail-fast validated at startup |
+| `NETOBS_DROP_FLOW_ALLOW_NAMESPACES` | `-drop-flow-allow-namespaces` | *(empty)* | Comma-separated namespace allow-list for `netobs_drop_events_flow_total` 5-tuple emit (#64). Empty disables emit cluster-wide. RFC1123 validated. See [docs/netobs/drop-flow-analysis.md](docs/netobs/drop-flow-analysis.md) |
+| `NETOBS_DROP_FLOW_MAX_ACTIVE` | `-drop-flow-max-active` | `1024` | LRU sampling cap for concurrent active 5-tuple flows in drop flow metric. Older flows are evicted when limit exceeded |
 | `NODE_NAME` | `-node-name` | *(hostname)* | Observed Kubernetes node name |
 | `KUBE_METADATA_REFRESH` | `-metadata-refresh` | `30s` | Kubernetes informer resync interval |
 | `DROP_REASON_FORMAT_PATH` | `-drop-reason-format` | `/sys/kernel/tracing/events/skb/kfree_skb/format` | skb:kfree_skb tracepoint format path. See [docs/netobs/drop-reason.md](docs/netobs/drop-reason.md) for the kernel 6.8 reason code table, the runtime mapping mechanism, the `drop_category` taxonomy, and PromQL examples |

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -60,7 +60,8 @@ struct netobs_start_info {
     __u8  seen_veth;
     __u8  seen_devq;
     __u8  ret_seen;
-    __u8  pad0;
+    __u8  protocol;         /* IP protocol number (IPPROTO_TCP=6, IPPROTO_UDP=17). #64 의 drop flow
+                              5-tuple emit 에 사용. pad0 자리를 reuse 해 struct size 변경 없음. */
 };
 
 struct netobs_event {
@@ -85,7 +86,9 @@ struct netobs_event {
     char  comm[NETOBS_COMM_LEN];
 
     __u8  stage;
-    __u8  pad[3];
+    __u8  protocol;         /* IP protocol number (IPPROTO_TCP=6, IPPROTO_UDP=17). #64 의 drop flow
+                              5-tuple emit 에 사용. pad[0] 자리를 reuse 해 struct size 변경 없음. */
+    __u8  pad[2];
 };
 
 #endif

--- a/bpf/common.h
+++ b/bpf/common.h
@@ -3,6 +3,11 @@
 
 #define NETOBS_COMM_LEN 16
 
+/* AF_INET 은 linux/socket.h 의 socket family 상수다. BPF 환경에서 vmlinux.h 는 enum 만 dump 하므로
+ * 본 매크로를 명시 정의해 #64 의 drop flow IPv4 가드 (sk_family == AF_INET) 에서 hardcoded 2 보다
+ * 가독성을 확보한다. */
+#define NETOBS_AF_INET 2
+
 enum netobs_event_stage {
     NETOBS_STAGE_SENDMSG_RET = 1,
     NETOBS_STAGE_TO_VETH     = 2,

--- a/bpf/netlat.bpf.c
+++ b/bpf/netlat.bpf.c
@@ -89,6 +89,11 @@ static __always_inline void fill_conn_from_sock(struct sock *sk, struct netobs_s
 
     s->ifindex = BPF_CORE_READ(sk, __sk_common.skc_bound_dev_if);
     s->skb_iif = 0;
+
+    /* #64 drop flow 5-tuple emit 에 protocol 라벨이 필요하다. sk_protocol 은 kernel 의 bitfield 라
+     * BPF_CORE_READ_BITFIELD_PROBED 매크로로 안전하게 읽는다. CO-RE 로 kernel 버전 간 layout
+     * 차이를 흡수한다. */
+    s->protocol = BPF_CORE_READ_BITFIELD_PROBED(sk, sk_protocol);
 }
 
 static __always_inline void fill_dev_from_skb(struct sk_buff *skb, struct netobs_start_info *s)
@@ -176,9 +181,9 @@ static __always_inline void emit_event(const struct netobs_start_info *s,
     __builtin_memcpy(e->comm, s->comm, sizeof(e->comm));
 
     e->stage         = stage;
+    e->protocol      = s->protocol;
     e->pad[0]        = 0;
     e->pad[1]        = 0;
-    e->pad[2]        = 0;
 
     bpf_ringbuf_submit(e, 0);
 }
@@ -356,9 +361,16 @@ int BPF_KPROBE(handle_kfree_skb_reason, struct sk_buff *skb, int reason)
     struct sock *sk;
     struct netobs_start_info s = {};
     __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u16 family;
 
     sk = BPF_CORE_READ(skb, sk);
     if (!sk)
+        return 0;
+
+    /* #64 의 drop flow 5-tuple 은 IPv4 한정 첫 구현이다. AF_INET (2) 외의 family (AF_INET6 등) 는
+     * 5-tuple 라벨 셋이 의미가 없어 본 drop event 의 emit 자체를 skip 한다. */
+    family = BPF_CORE_READ(sk, __sk_common.skc_family);
+    if (family != 2 /* AF_INET */)
         return 0;
 
     s.ts_ns     = bpf_ktime_get_ns();

--- a/bpf/netlat.bpf.c
+++ b/bpf/netlat.bpf.c
@@ -367,10 +367,10 @@ int BPF_KPROBE(handle_kfree_skb_reason, struct sk_buff *skb, int reason)
     if (!sk)
         return 0;
 
-    /* #64 의 drop flow 5-tuple 은 IPv4 한정 첫 구현이다. AF_INET (2) 외의 family (AF_INET6 등) 는
-     * 5-tuple 라벨 셋이 의미가 없어 본 drop event 의 emit 자체를 skip 한다. */
+    /* #64 의 drop flow 5-tuple 은 IPv4 한정 첫 구현이다. NETOBS_AF_INET 외의 family (AF_INET6 등)
+     * 는 5-tuple 라벨 셋이 의미가 없어 본 drop event 의 emit 자체를 skip 한다. */
     family = BPF_CORE_READ(sk, __sk_common.skc_family);
-    if (family != 2 /* AF_INET */)
+    if (family != NETOBS_AF_INET)
         return 0;
 
     s.ts_ns     = bpf_ktime_get_ns();

--- a/cmd/netobs-agent/main.go
+++ b/cmd/netobs-agent/main.go
@@ -42,6 +42,14 @@ func main() {
 	// 노드 NIC capacity tunable을 정적 gauge로 노출해 correlation recording rule이 분모로 사용한다.
 	metrics.SetNICCapacityBytesPerSec(cfg.NodeName, cfg.NICCapacityBytesPerSec)
 	log.Printf("nic capacity: %.0f bytes/sec (node=%s)", cfg.NICCapacityBytesPerSec, cfg.NodeName)
+	// #64 의 drop flow 5-tuple 메트릭 cardinality 가드. allow-list 가 비어 있으면 emit 자체가 skip
+	// 되어 카디널리티 0 series 로 유지된다. 운영자가 진단 대상 namespace 만 명시 등록.
+	if len(cfg.DropFlowAllowNamespaces) > 0 {
+		metrics.SetDropFlowGuard(metrics.NewDropFlowGuard(cfg.DropFlowAllowNamespaces, cfg.DropFlowMaxActive))
+		log.Printf("drop flow guard: allow_namespaces=%v max_active=%d", cfg.DropFlowAllowNamespaces, cfg.DropFlowMaxActive)
+	} else {
+		log.Printf("drop flow guard: disabled (NETOBS_DROP_FLOW_ALLOW_NAMESPACES empty)")
+	}
 
 	var ebpfReady atomic.Bool
 	kr := kube.NewResolver(cfg.NodeName, cfg.MetadataRefresh)

--- a/deploy/gpuobs/base/prometheus-rule.yaml
+++ b/deploy/gpuobs/base/prometheus-rule.yaml
@@ -358,10 +358,10 @@ spec:
             description: "drop category {{ $labels.drop_category }} for workload {{ $labels.src_namespace }}/{{ $labels.src_workload }} on node {{ $labels.node }} is {{ $value }} events/sec sustained over 2 minutes. Reference docs/netobs/drop-reason.md for category semantics."
 
         # NetObsDropBurst
-        # 동일 5-tuple 에서 10 회 이상 drop 이 burst 로 발생하고 30 초 지속 시 발화한다 (#64). 본
-        # alert 는 netobs_drop_events_flow_total 메트릭이 emit 되는 namespace 한정으로 동작하며
-        # cardinality 가드를 통과한 5-tuple 만 검출 대상이다. burst rate 임계 10/s 는 dev cluster 의
-        # 합성 drop 시나리오 (iptables -j DROP) 에서 sustained burst 의 하한값으로 검증되었다.
+        # 동일 5-tuple 에서 drop rate 가 10 회/초 이상이고 1 분 지속 시 발화한다 (#64). 본 alert 는
+        # netobs_drop_events_flow_total 메트릭이 emit 되는 namespace 한정으로 동작하며 cardinality
+        # 가드를 통과한 5-tuple 만 검출 대상이다. burst rate 임계 10/s 는 dev cluster 의 합성 drop
+        # 시나리오 (iptables -j DROP) 에서 sustained burst 의 하한값으로 검증되었다.
         - alert: NetObsDropBurst
           expr: |
             netobs_drop_burst:rate1m > 10
@@ -371,7 +371,7 @@ spec:
             component: netobs
           annotations:
             summary: "netobs drop burst on 5-tuple (src={{ $labels.src_namespace }}/{{ $labels.src_pod }} dst={{ $labels.dst_ip }}:{{ $labels.dst_port }} proto={{ $labels.protocol }} reason={{ $labels.drop_reason }})"
-            description: "drop burst rate {{ $value }} events/sec sustained over 30 seconds for 5-tuple src={{ $labels.src_ip }}:{{ $labels.src_port }} → dst={{ $labels.dst_ip }}:{{ $labels.dst_port }} protocol={{ $labels.protocol }} drop_reason={{ $labels.drop_reason }}. See docs/netobs/drop-flow-analysis.md for triage workflow."
+            description: "drop burst rate {{ $value }} events/sec sustained over 1 minute for 5-tuple src={{ $labels.src_ip }}:{{ $labels.src_port }} → dst={{ $labels.dst_ip }}:{{ $labels.dst_port }} protocol={{ $labels.protocol }} drop_reason={{ $labels.drop_reason }}. See docs/netobs/drop-flow-analysis.md for triage workflow."
 
         # NetObsHighRetransmissionRate
         # TCP 재전송 rate가 5event/s를 넘으면 발화. 네트워크 혼잡, peer 처리 지연, 경로 패킷

--- a/deploy/gpuobs/base/prometheus-rule.yaml
+++ b/deploy/gpuobs/base/prometheus-rule.yaml
@@ -236,20 +236,21 @@ spec:
             )
 
     # netobs-gpuobs.drop-flow.recording 그룹은 #64 의 drop flow 5-tuple burst 검출을 위한 recording
-    # rule 을 둔다. interval 10s 로 짧게 평가해 burst 시점을 정확히 잡고 stale 시리즈는 자연스럽게
-    # rate window 가 만료되며 사라진다.
+    # rule 을 둔다. evaluation interval 30s, rate window 1m 으로 두어 ServiceMonitor 의 scrape
+    # interval (15s) 보다 충분히 길어 sample 부족으로 인한 빈 결과를 회피한다. rate window 가 1m
+    # 라 1 분 안의 burst 평균값을 산출하며 short burst (수 초 단위) 는 평균이 희석된다. 본 trade-off
+    # 는 운영 환경의 sustained burst 감지 (alert) 가 우선이라 채택한다.
     - name: netobs-gpuobs.drop-flow.recording
-      interval: 10s
+      interval: 30s
       rules:
-        # netobs_drop_burst:rate10s
-        # 동일 5-tuple 의 drop 횟수가 10초 윈도우에서 초당 N 회 (rate > 1/s) 이상이면 burst 후보로
-        # 분류한다. dst_ip 와 dst_port 그룹별 src_namespace / src_pod 합산을 본 rule 의 라벨 집합
-        # 으로 보존해 alert 에서 5-tuple 단위 식별이 가능하다. drop_reason 도 라벨로 두어 reason 별
-        # burst 패턴 (예: NF_DROP_CONNTRACK 가 dominant) 식별이 가능하다.
-        - record: netobs_drop_burst:rate10s
+        # netobs_drop_burst:rate1m
+        # 동일 5-tuple 의 drop 횟수를 1 분 윈도우에서 초당 평균으로 산출한다. src_namespace /
+        # src_pod / 5-tuple / drop_reason / drop_category 라벨을 보존해 alert 에서 정확한 connection
+        # 단위 식별이 가능하다.
+        - record: netobs_drop_burst:rate1m
           expr: |
             sum by(src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category) (
-              rate(netobs_drop_events_flow_total[10s])
+              rate(netobs_drop_events_flow_total[1m])
             )
 
     # netobs-gpuobs.cluster-health.recording 그룹은 cluster 전체 단위의 4 카테고리 health score 를
@@ -363,8 +364,8 @@ spec:
         # 합성 drop 시나리오 (iptables -j DROP) 에서 sustained burst 의 하한값으로 검증되었다.
         - alert: NetObsDropBurst
           expr: |
-            netobs_drop_burst:rate10s > 10
-          for: 30s
+            netobs_drop_burst:rate1m > 10
+          for: 1m
           labels:
             severity: warning
             component: netobs

--- a/deploy/gpuobs/base/prometheus-rule.yaml
+++ b/deploy/gpuobs/base/prometheus-rule.yaml
@@ -235,6 +235,23 @@ spec:
               pod:gpu_memory_utilization_ratio:5m
             )
 
+    # netobs-gpuobs.drop-flow.recording 그룹은 #64 의 drop flow 5-tuple burst 검출을 위한 recording
+    # rule 을 둔다. interval 10s 로 짧게 평가해 burst 시점을 정확히 잡고 stale 시리즈는 자연스럽게
+    # rate window 가 만료되며 사라진다.
+    - name: netobs-gpuobs.drop-flow.recording
+      interval: 10s
+      rules:
+        # netobs_drop_burst:rate10s
+        # 동일 5-tuple 의 drop 횟수가 10초 윈도우에서 초당 N 회 (rate > 1/s) 이상이면 burst 후보로
+        # 분류한다. dst_ip 와 dst_port 그룹별 src_namespace / src_pod 합산을 본 rule 의 라벨 집합
+        # 으로 보존해 alert 에서 5-tuple 단위 식별이 가능하다. drop_reason 도 라벨로 두어 reason 별
+        # burst 패턴 (예: NF_DROP_CONNTRACK 가 dominant) 식별이 가능하다.
+        - record: netobs_drop_burst:rate10s
+          expr: |
+            sum by(src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category) (
+              rate(netobs_drop_events_flow_total[10s])
+            )
+
     # netobs-gpuobs.cluster-health.recording 그룹은 cluster 전체 단위의 4 카테고리 health score 를
     # 산출한다. observability overview dashboard (#53) 의 single-stat 패널이 본 record 4 종을 직접
     # 참조한다. 각 score 는 0 ~ 1 사이로 정규화되며 1 이 healthy, 0 이 worst 다. cluster 의 어느 노드
@@ -338,6 +355,22 @@ spec:
           annotations:
             summary: "netobs drop rate over 10/s (node={{ $labels.node }} category={{ $labels.drop_category }})"
             description: "drop category {{ $labels.drop_category }} for workload {{ $labels.src_namespace }}/{{ $labels.src_workload }} on node {{ $labels.node }} is {{ $value }} events/sec sustained over 2 minutes. Reference docs/netobs/drop-reason.md for category semantics."
+
+        # NetObsDropBurst
+        # 동일 5-tuple 에서 10 회 이상 drop 이 burst 로 발생하고 30 초 지속 시 발화한다 (#64). 본
+        # alert 는 netobs_drop_events_flow_total 메트릭이 emit 되는 namespace 한정으로 동작하며
+        # cardinality 가드를 통과한 5-tuple 만 검출 대상이다. burst rate 임계 10/s 는 dev cluster 의
+        # 합성 drop 시나리오 (iptables -j DROP) 에서 sustained burst 의 하한값으로 검증되었다.
+        - alert: NetObsDropBurst
+          expr: |
+            netobs_drop_burst:rate10s > 10
+          for: 30s
+          labels:
+            severity: warning
+            component: netobs
+          annotations:
+            summary: "netobs drop burst on 5-tuple (src={{ $labels.src_namespace }}/{{ $labels.src_pod }} dst={{ $labels.dst_ip }}:{{ $labels.dst_port }} proto={{ $labels.protocol }} reason={{ $labels.drop_reason }})"
+            description: "drop burst rate {{ $value }} events/sec sustained over 30 seconds for 5-tuple src={{ $labels.src_ip }}:{{ $labels.src_port }} → dst={{ $labels.dst_ip }}:{{ $labels.dst_port }} protocol={{ $labels.protocol }} drop_reason={{ $labels.drop_reason }}. See docs/netobs/drop-flow-analysis.md for triage workflow."
 
         # NetObsHighRetransmissionRate
         # TCP 재전송 rate가 5event/s를 넘으면 발화. 네트워크 혼잡, peer 처리 지연, 경로 패킷

--- a/docs/netobs/drop-flow-analysis.md
+++ b/docs/netobs/drop-flow-analysis.md
@@ -1,0 +1,88 @@
+# drop flow 5-tuple 분석 가이드
+
+`netobs_drop_events_flow_total` 메트릭과 `NetObsDropBurst` alert로 packet drop의 정확한 5-tuple flow를 식별하는 운영 워크플로다. 본 도구는 #64에서 도입되었으며 기존 `netobs_drop_events_labeled_total` 의 workload 단위 emit 을 보완해 connection 단위 진단을 즉시 가능하게 한다.
+
+## 메트릭 카탈로그
+
+- `netobs_drop_events_flow_total{node, src_namespace, src_workload, traffic_scope, direction, drop_reason, drop_category, protocol, src_ip, src_port, dst_ip, dst_port}` counter. drop event의 5-tuple flow context emit
+- `netobs_drop_burst:rate10s{src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category}` recording rule. 10초 윈도우 rate 산출
+
+## 활성화 절차
+
+`netobs_drop_events_flow_total` 은 cardinality 위험이 크다. 운영자가 진단 대상 namespace를 명시 등록해야 emit이 시작된다.
+
+```sh
+# DaemonSet env로 namespace allow-list 주입
+kubectl -n ebpf-project set env daemonset/netobs-agent \
+  NETOBS_DROP_FLOW_ALLOW_NAMESPACES=correlation-stress,my-app
+
+# rollout 후 메트릭 확인
+kubectl rollout status -n ebpf-project daemonset/netobs-agent
+PROM_POD=$(kubectl get pod -n monitoring -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n monitoring $PROM_POD -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=netobs_drop_events_flow_total' | jq
+```
+
+빈 allow-list가 기본값이며 그 경우 emit 자체가 일어나지 않아 cardinality가 0 series로 유지된다.
+
+## 카디널리티 분석
+
+emit되는 series 수의 절대 상한은 다음으로 산정한다.
+
+```
+series 상한 = NETOBS_DROP_FLOW_MAX_ACTIVE × drop_reason 수
+           = 1024 × 8 = 8,192 series per node
+```
+
+기본값 `NETOBS_DROP_FLOW_MAX_ACTIVE=1024` 는 LRU eviction으로 가장 오래된 flow가 자동 정리되어 본 한도를 절대 초과하지 않는다. 4 노드 cluster 기준 총 32k series 이내, 이슈 #64 의 100k 상한 안에 있다.
+
+`NETOBS_DROP_FLOW_MAX_ACTIVE` 를 1024 외 값으로 운영자가 바꾸면 본 산식에 따라 series 상한이 비례한다.
+
+## `NetObsDropBurst` alert runbook
+
+alert가 발화하면 다음 4 단계로 root cause를 좁힌다.
+
+### 1단계 — alert label에서 5-tuple 추출
+
+alert label의 `src_namespace`, `src_pod`, `src_ip`, `src_port`, `dst_ip`, `dst_port`, `protocol`, `drop_reason` 8 필드가 burst의 정체성을 정의한다. 본 라벨 조합이 정확한 connection을 가리킨다.
+
+### 2단계 — drop_reason 분류 확인
+
+drop_category가 다음 4 종 중 어디에 속하는지 확인한다.
+
+- `tx`: 송신 측 drop (NIC queue full, qdisc dropped, ICMP send fail 등). 노드 NIC 자원 압박 의심
+- `rx`: 수신 측 drop (skb pulled, GRO drop 등). 수신 노드 또는 NIC 압박
+- `netfilter`: conntrack / iptables / ipv6 disabled 등 정책 drop. cluster network policy 또는 noprol firewall 확인
+- `tcp`: TCP retransmit timer, rst 등 transport 계층 drop
+
+drop_category 별 의미는 [docs/netobs/drop-reason.md](drop-reason.md) 참고.
+
+### 3단계 — 동시 신호 cross-reference
+
+burst 시점의 다음 메트릭을 같은 시간대에 확인한다.
+
+- `gpuobs_device_pcie_rx_bytes_per_second` 와 `gpuobs_device_pcie_tx_bytes_per_second`: GPU 노드의 PCIe 포화 여부
+- `pod:cpu_throttle_score:5m`: src_pod의 cpu 압박
+- `pod:memory_pressure_score:5m`: src_pod의 메모리 압박
+- `correlation_noisy_neighbor_score{victim_pod=$src_pod}`: src_pod가 다른 워크로드의 영향을 받는지
+
+### 4단계 — 합성 부하 검증
+
+drop이 자연 발생이라면 #52 의 `workload-injector` 로 동일 src_pod에 합성 부하를 추가해 burst 패턴이 재현되는지 확인한다.
+
+```sh
+kubectl apply -f test/injector-examples/network.yaml  # network 부하 inject 후 burst 재현 확인
+```
+
+## 트러블슈팅
+
+- **`netobs_drop_events_flow_total` 가 비어 있음**: `NETOBS_DROP_FLOW_ALLOW_NAMESPACES` 가 비어 있음. allow-list 등록 후 DaemonSet rollout 필요
+- **burst alert가 5분 지나도 발화 안 함**: drop rate 가 10/s 임계 미만. 합성 시나리오로 검증하려면 iptables `-A FORWARD -d <pod_ip> -j DROP` 으로 sustained drop 발생
+- **5-tuple 의 src_ip가 0.0.0.0 또는 dst_ip가 0.0.0.0**: socket이 bind 되기 전 drop. sk_protocol bitfield가 0 으로 emit되는 edge case로 본 series는 무시 가능
+- **protocol 라벨이 "unknown"**: TCP / UDP 외 protocol (ICMP, GRE 등). 본 첫 구현은 TCP / UDP 한정이며 추후 확장 예정
+
+## 비목표 (#64 의 follow-up)
+
+- IPv6 5-tuple 은 별도 이슈에서 다룬다. 본 가이드는 IPv4 한정
+- conntrack table dump의 자동 통합은 본 이슈 범위 밖이다
+- drop 시점의 socket buffer 상태와 TCP 윈도우 추적은 본 이슈 범위 밖이다

--- a/docs/netobs/drop-flow-analysis.md
+++ b/docs/netobs/drop-flow-analysis.md
@@ -4,7 +4,7 @@
 
 ## 메트릭 카탈로그
 
-- `netobs_drop_events_flow_total{node, src_namespace, src_workload, traffic_scope, direction, drop_reason, drop_category, protocol, src_ip, src_port, dst_ip, dst_port}` counter. drop event의 5-tuple flow context emit
+- `netobs_drop_events_flow_total{node, src_namespace, src_workload, src_pod, traffic_scope, direction, drop_reason, drop_category, protocol, src_ip, src_port, dst_ip, dst_port}` counter. drop event의 5-tuple flow context emit
 - `netobs_drop_burst:rate1m{src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category}` recording rule. 1분 윈도우 rate 산출. evaluation interval 30s, ServiceMonitor scrape interval (15s) 보다 충분히 긴 rate window로 sample 부족을 회피
 
 ## 활성화 절차
@@ -44,7 +44,7 @@ alert가 발화하면 다음 4 단계로 root cause를 좁힌다.
 
 ### 1단계 — alert label에서 5-tuple 추출
 
-alert label의 `src_namespace`, `src_pod`, `src_ip`, `src_port`, `dst_ip`, `dst_port`, `protocol`, `drop_reason` 8 필드가 burst의 정체성을 정의한다. 본 라벨 조합이 정확한 connection을 가리킨다.
+alert label의 `src_namespace`, `src_pod`, `src_ip`, `src_port`, `dst_ip`, `dst_port`, `protocol`, `drop_reason`, `drop_category` 9 필드가 burst의 정체성을 정의한다. 본 라벨 조합이 정확한 connection과 해당 drop 분류를 함께 가리킨다.
 
 ### 2단계 — drop_reason 분류 확인
 
@@ -77,8 +77,8 @@ kubectl apply -f test/injector-examples/network.yaml  # network 부하 inject �
 ## 트러블슈팅
 
 - **`netobs_drop_events_flow_total` 가 비어 있음**: `NETOBS_DROP_FLOW_ALLOW_NAMESPACES` 가 비어 있음. allow-list 등록 후 DaemonSet rollout 필요
-- **burst alert가 5분 지나도 발화 안 함**: drop rate 가 10/s 임계 미만. 합성 시나리오로 검증하려면 iptables `-A FORWARD -d <pod_ip> -j DROP` 으로 sustained drop 발생
-- **5-tuple 의 src_ip가 0.0.0.0 또는 dst_ip가 0.0.0.0**: socket이 bind 되기 전 drop. sk_protocol bitfield가 0 으로 emit되는 edge case로 본 series는 무시 가능
+- **burst alert가 1분 이상 지속돼도 발화 안 함**: drop rate가 10/s 임계 미만이거나 sustain 시간이 alert rule의 `for: 1m` 조건을 만족하지 않음. 합성 시나리오로 검증하려면 iptables `-A FORWARD -d <pod_ip> -j DROP`으로 1분 이상 sustained drop 발생
+- **`0.0.0.0` 또는 빈 IP를 기대한 5-tuple series가 보이지 않음**: 정상 동작. `DropFlowGuard`가 socket bind 전 drop의 5-tuple을 LRU 등록 단계에서 거부하므로 해당 series는 `netobs_drop_events_flow_total`에 나타나지 않음
 - **protocol 라벨이 "unknown"**: TCP / UDP 외 protocol (ICMP, GRE 등). 본 첫 구현은 TCP / UDP 한정이며 추후 확장 예정
 
 ## 비목표 (#64 의 follow-up)

--- a/docs/netobs/drop-flow-analysis.md
+++ b/docs/netobs/drop-flow-analysis.md
@@ -5,7 +5,7 @@
 ## 메트릭 카탈로그
 
 - `netobs_drop_events_flow_total{node, src_namespace, src_workload, traffic_scope, direction, drop_reason, drop_category, protocol, src_ip, src_port, dst_ip, dst_port}` counter. drop event의 5-tuple flow context emit
-- `netobs_drop_burst:rate10s{src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category}` recording rule. 10초 윈도우 rate 산출
+- `netobs_drop_burst:rate1m{src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category}` recording rule. 1분 윈도우 rate 산출. evaluation interval 30s, ServiceMonitor scrape interval (15s) 보다 충분히 긴 rate window로 sample 부족을 회피
 
 ## 활성화 절차
 

--- a/internal/netobs/config/config.go
+++ b/internal/netobs/config/config.go
@@ -51,6 +51,17 @@ type Config struct {
 	// 식별 흐름에 한해 UID가 채워져 카디널리티 폭발을 막는다.
 	PodFlowDstUIDAllowNamespaces []string
 
+	// DropFlowAllowNamespaces 는 netobs_drop_events_flow_total 의 5-tuple 메트릭이 emit 되는 src
+	// namespace 화이트리스트다 (#64). 본 메트릭은 src_ip / src_port / dst_ip / dst_port / protocol 5
+	// 라벨로 카디널리티 위험이 크다. 빈 슬라이스가 기본이며 그 경우 emit 자체가 일어나지 않는다.
+	// 운영자가 진단 대상 namespace 만 명시 등록해 series 폭주를 차단한다.
+	DropFlowAllowNamespaces []string
+
+	// DropFlowMaxActive 는 활성 5-tuple flow 의 동시 emit 상한이다. LRU sampling 으로 본 한도를 초과
+	// 하는 신규 flow 는 가장 오래된 flow 가 evict 된 후 등록된다. emit 되는 series 의 절대 상한은
+	// DropFlowMaxActive * (drop_reason 수 8 종) 으로 추정된다. 기본 1024.
+	DropFlowMaxActive int
+
 	// NICCapacityBytesPerSec는 노드의 NIC 이론 capacity (bytes/sec) 다. correlation 진단의 network
 	// throughput score 정규화 분모로 사용되는 netobs_node_nic_capacity_bytes_per_sec 메트릭의 값을
 	// 결정한다. default 1.25e9 (10 GbE) 가 일반 서버 NIC와 정합하고, 운영자는 노드별 실제 NIC 사양에
@@ -151,6 +162,11 @@ func Parse() (Config, error) {
 		return Config{}, err
 	}
 
+	dropFlowMaxActive, err := strconv.Atoi(getenv("NETOBS_DROP_FLOW_MAX_ACTIVE", "1024"))
+	if err != nil || dropFlowMaxActive <= 0 {
+		dropFlowMaxActive = 1024
+	}
+
 	cfg := Config{
 		TargetIP:                     getenv("TARGET_IP", ""),
 		ListenAddr:                   getenv("LISTEN_ADDR", ":9810"),
@@ -161,6 +177,8 @@ func Parse() (Config, error) {
 		DropReasonFormatPath:         getenv("DROP_REASON_FORMAT_PATH", "/sys/kernel/tracing/events/skb/kfree_skb/format"),
 		PodFlowDstEnabled:            getenvBool("POD_FLOW_DST_ENABLED", true),
 		PodFlowDstUIDAllowNamespaces: parseNamespaceList(getenv("POD_FLOW_DST_UID_ALLOW_NAMESPACES", "")),
+		DropFlowAllowNamespaces:      parseNamespaceList(getenv("NETOBS_DROP_FLOW_ALLOW_NAMESPACES", "")),
+		DropFlowMaxActive:            dropFlowMaxActive,
 		NICCapacityBytesPerSec:       nicCapacity,
 	}
 
@@ -178,6 +196,12 @@ func Parse() (Config, error) {
 		dstUIDNs = strings.Join(cfg.PodFlowDstUIDAllowNamespaces, ",")
 	}
 	fs.StringVar(&dstUIDNs, "pod-flow-dst-uid-allow-namespaces", dstUIDNs, "comma-separated namespace allow-list whose Pods receive dst_pod_uid labels; empty disables UID emit cluster-wide")
+	var dropFlowNs string
+	if len(cfg.DropFlowAllowNamespaces) > 0 {
+		dropFlowNs = strings.Join(cfg.DropFlowAllowNamespaces, ",")
+	}
+	fs.StringVar(&dropFlowNs, "drop-flow-allow-namespaces", dropFlowNs, "comma-separated namespace allow-list for netobs_drop_events_flow_total 5-tuple emit (#64); empty disables emit cluster-wide")
+	fs.IntVar(&cfg.DropFlowMaxActive, "drop-flow-max-active", cfg.DropFlowMaxActive, "LRU sampling cap for concurrent active 5-tuple flows in drop flow metric (#64). Older flows are evicted when limit exceeded")
 	fs.Float64Var(&cfg.NICCapacityBytesPerSec, "nic-capacity-bytes", cfg.NICCapacityBytesPerSec, "node NIC theoretical capacity in bytes/sec; exposed as netobs_node_nic_capacity_bytes_per_sec for correlation network throughput score (default 1.25e9 = 10 GbE)")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		// -h/-help 요청은 flag 패키지가 usage를 출력한 뒤 ErrHelp를 반환한다.
@@ -204,6 +228,7 @@ func Parse() (Config, error) {
 	// 통과시킨다. env-only 경로와 flag-override 경로가 같은 정상화 규칙을 공유해 운영 surface가
 	// 일관되게 동작한다.
 	cfg.PodFlowDstUIDAllowNamespaces = parseNamespaceList(dstUIDNs)
+	cfg.DropFlowAllowNamespaces = parseNamespaceList(dropFlowNs)
 
 	// allow-list 각 entry 가 RFC1123 DNS 라벨 규칙에 맞는지 startup 시점에 fail-fast 로 검증한다.
 	// 잘못된 이름 (예: 대문자, 언더스코어 오타) 은 lookup 단계에서 silent miss 가 되어 dst_pod_uid
@@ -212,6 +237,14 @@ func Parse() (Config, error) {
 		if err := validateNamespaceName(ns); err != nil {
 			return Config{}, fmt.Errorf("invalid -pod-flow-dst-uid-allow-namespaces entry: %w", err)
 		}
+	}
+	for _, ns := range cfg.DropFlowAllowNamespaces {
+		if err := validateNamespaceName(ns); err != nil {
+			return Config{}, fmt.Errorf("invalid -drop-flow-allow-namespaces entry: %w", err)
+		}
+	}
+	if cfg.DropFlowMaxActive <= 0 {
+		return Config{}, fmt.Errorf("drop-flow-max-active must be positive, got %d", cfg.DropFlowMaxActive)
 	}
 
 	return cfg, nil

--- a/internal/netobs/ebpf/netobs_bpfeb.go
+++ b/internal/netobs/ebpf/netobs_bpfeb.go
@@ -40,7 +40,7 @@ type NetObsNetobsStartInfo struct {
 	SeenVeth     uint8
 	SeenDevq     uint8
 	RetSeen      uint8
-	Pad0         uint8
+	Protocol     uint8
 }
 
 // LoadNetObs returns the embedded CollectionSpec for NetObs.

--- a/internal/netobs/ebpf/netobs_bpfel.go
+++ b/internal/netobs/ebpf/netobs_bpfel.go
@@ -40,7 +40,7 @@ type NetObsNetobsStartInfo struct {
 	SeenVeth     uint8
 	SeenDevq     uint8
 	RetSeen      uint8
-	Pad0         uint8
+	Protocol     uint8
 }
 
 // LoadNetObs returns the embedded CollectionSpec for NetObs.

--- a/internal/netobs/metadata/enricher.go
+++ b/internal/netobs/metadata/enricher.go
@@ -386,6 +386,7 @@ func (e *Enricher) Enrich(ev types.Event, mapper *drop.Mapper) types.EnrichedEve
 		ObservedNode:   e.kr.LocalNode(),
 		SrcIPText:      srcIP,
 		DstIPText:      dstIP,
+		ProtocolText:   types.IPProtocolName(ev.Protocol),
 		Src:            src,
 		Dst:            dst,
 		DropReasonName: reasonName,

--- a/internal/netobs/metrics/dropflow.go
+++ b/internal/netobs/metrics/dropflow.go
@@ -31,8 +31,12 @@ type flowKey struct {
 }
 
 // NewDropFlowGuard 는 namespace allow-list 와 LRU 상한으로 가드를 구성한다. allowList 가 빈 슬라이스
-// 면 모든 src_namespace 가 거부된다 (cardinality 안전 default). maxActive 가 양수여야 한다.
+// 면 모든 src_namespace 가 거부된다 (cardinality 안전 default). maxActive 가 0 이하면 1024 로
+// fallback 해 LRU eviction 이 비활성화된 무제한 entry 증가 상태를 library 단에서 차단한다.
 func NewDropFlowGuard(allowList []string, maxActive int) *DropFlowGuard {
+	if maxActive <= 0 {
+		maxActive = 1024
+	}
 	allowSet := make(map[string]struct{}, len(allowList))
 	for _, ns := range allowList {
 		allowSet[ns] = struct{}{}

--- a/internal/netobs/metrics/dropflow.go
+++ b/internal/netobs/metrics/dropflow.go
@@ -47,9 +47,13 @@ func NewDropFlowGuard(allowList []string, maxActive int) *DropFlowGuard {
 
 // Admit 은 (src_namespace, 5-tuple) 페어가 emit 자격이 있는지 판정하고 LRU 에 등록한다.
 // namespace 가 allow-list 에 없으면 false 반환. LRU 상한 초과 시 가장 오래된 entry 가 evict 된 후
-// 신규 entry 가 등록되며 신규는 admit 된다.
+// 신규 entry 가 등록되며 신규는 admit 된다. 빈 IP 또는 0.0.0.0 의 5-tuple 은 socket bind 전 drop
+// 으로 정확한 connection 식별이 불가하므로 LRU 등록 자체를 거부해 cache 공간이 낭비되지 않게 한다.
 func (g *DropFlowGuard) Admit(srcNamespace, srcIP string, srcPort uint16, dstIP string, dstPort uint16, protocol string) bool {
 	if _, ok := g.allowSet[srcNamespace]; !ok {
+		return false
+	}
+	if srcIP == "" || srcIP == "0.0.0.0" || dstIP == "" || dstIP == "0.0.0.0" {
 		return false
 	}
 	k := flowKey{srcNamespace, srcIP, srcPort, dstIP, dstPort, protocol}

--- a/internal/netobs/metrics/dropflow.go
+++ b/internal/netobs/metrics/dropflow.go
@@ -1,0 +1,79 @@
+// Package metrics 의 dropflow.go 는 #64 의 netobs_drop_events_flow_total 메트릭에 대한 cardinality
+// 가드 (namespace allow-list, top-N LRU sampling) 를 구현한다. 본 라이브러리는 emit 직전에 호출되어
+// 가드 통과한 (src_namespace, 5-tuple) 만 메트릭 카운터를 증가시키도록 한다.
+package metrics
+
+import (
+	"container/list"
+	"sync"
+)
+
+// DropFlowGuard 는 namespace allow-list 와 top-N LRU sampling 두 가드를 노출한다. injector_active 와
+// 동일하게 단일 cycle 안에서 emit / evict 가 직렬화되어 race 위험은 sync.Mutex 로 보호한다.
+type DropFlowGuard struct {
+	allowSet map[string]struct{}
+	maxN     int
+
+	mu    sync.Mutex
+	lru   *list.List
+	index map[flowKey]*list.Element
+}
+
+// flowKey 는 LRU 의 entry 식별 키다. emit 라벨 셋과 정확히 일치해 동일 5-tuple 의 재방문이 캐시 hit
+// 으로 처리된다.
+type flowKey struct {
+	srcNamespace string
+	srcIP        string
+	srcPort      uint16
+	dstIP        string
+	dstPort      uint16
+	protocol     string
+}
+
+// NewDropFlowGuard 는 namespace allow-list 와 LRU 상한으로 가드를 구성한다. allowList 가 빈 슬라이스
+// 면 모든 src_namespace 가 거부된다 (cardinality 안전 default). maxActive 가 양수여야 한다.
+func NewDropFlowGuard(allowList []string, maxActive int) *DropFlowGuard {
+	allowSet := make(map[string]struct{}, len(allowList))
+	for _, ns := range allowList {
+		allowSet[ns] = struct{}{}
+	}
+	return &DropFlowGuard{
+		allowSet: allowSet,
+		maxN:     maxActive,
+		lru:      list.New(),
+		index:    make(map[flowKey]*list.Element, maxActive),
+	}
+}
+
+// Admit 은 (src_namespace, 5-tuple) 페어가 emit 자격이 있는지 판정하고 LRU 에 등록한다.
+// namespace 가 allow-list 에 없으면 false 반환. LRU 상한 초과 시 가장 오래된 entry 가 evict 된 후
+// 신규 entry 가 등록되며 신규는 admit 된다.
+func (g *DropFlowGuard) Admit(srcNamespace, srcIP string, srcPort uint16, dstIP string, dstPort uint16, protocol string) bool {
+	if _, ok := g.allowSet[srcNamespace]; !ok {
+		return false
+	}
+	k := flowKey{srcNamespace, srcIP, srcPort, dstIP, dstPort, protocol}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if e, ok := g.index[k]; ok {
+		g.lru.MoveToFront(e)
+		return true
+	}
+	if g.lru.Len() >= g.maxN {
+		oldest := g.lru.Back()
+		if oldest != nil {
+			delete(g.index, oldest.Value.(flowKey))
+			g.lru.Remove(oldest)
+		}
+	}
+	e := g.lru.PushFront(k)
+	g.index[k] = e
+	return true
+}
+
+// Size 는 현재 LRU 가 추적 중인 entry 수를 반환한다. 단위 테스트와 운영 디버깅용.
+func (g *DropFlowGuard) Size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.lru.Len()
+}

--- a/internal/netobs/metrics/dropflow_test.go
+++ b/internal/netobs/metrics/dropflow_test.go
@@ -13,6 +13,21 @@ func TestDropFlowGuard_AllowList(t *testing.T) {
 	}
 }
 
+// TestDropFlowGuard_RejectsZeroIP 는 socket bind 전 drop (saddr/daddr=0) 의 5-tuple 이 LRU 등록
+// 거부되는지 검증한다. cache 공간 낭비 방지 가드의 회귀 가드.
+func TestDropFlowGuard_RejectsZeroIP(t *testing.T) {
+	g := NewDropFlowGuard([]string{"ns"}, 100)
+	if g.Admit("ns", "0.0.0.0", 80, "10.0.0.2", 81, "TCP") {
+		t.Errorf("0.0.0.0 srcIP 가 admit 됨")
+	}
+	if g.Admit("ns", "10.0.0.1", 80, "", 81, "TCP") {
+		t.Errorf("empty dstIP 가 admit 됨")
+	}
+	if g.Size() != 0 {
+		t.Errorf("size=%d want 0 (reject 후 LRU 비어 있어야 함)", g.Size())
+	}
+}
+
 // TestDropFlowGuard_EmptyAllowListRejects 는 빈 allow-list 가 모든 emit 을 차단하는지 검증.
 // cardinality 안전 default 의 회귀 가드.
 func TestDropFlowGuard_EmptyAllowListRejects(t *testing.T) {

--- a/internal/netobs/metrics/dropflow_test.go
+++ b/internal/netobs/metrics/dropflow_test.go
@@ -1,0 +1,58 @@
+package metrics
+
+import "testing"
+
+// TestDropFlowGuard_AllowList 는 namespace 가 allow-list 에 없으면 Admit 이 false 반환하는지 검증.
+func TestDropFlowGuard_AllowList(t *testing.T) {
+	g := NewDropFlowGuard([]string{"correlation-stress"}, 100)
+	if g.Admit("not-allowed", "10.0.0.1", 80, "10.0.0.2", 81, "TCP") {
+		t.Errorf("not-allowed namespace 가 Admit 됨")
+	}
+	if !g.Admit("correlation-stress", "10.0.0.1", 80, "10.0.0.2", 81, "TCP") {
+		t.Errorf("allowed namespace 가 reject 됨")
+	}
+}
+
+// TestDropFlowGuard_EmptyAllowListRejects 는 빈 allow-list 가 모든 emit 을 차단하는지 검증.
+// cardinality 안전 default 의 회귀 가드.
+func TestDropFlowGuard_EmptyAllowListRejects(t *testing.T) {
+	g := NewDropFlowGuard(nil, 100)
+	if g.Admit("any-namespace", "10.0.0.1", 80, "10.0.0.2", 81, "TCP") {
+		t.Errorf("empty allow-list 가 admit 함 (cardinality 위험)")
+	}
+}
+
+// TestDropFlowGuard_LRUEvicts 는 maxActive 초과 시 가장 오래된 flow 가 evict 되고 신규는 admit 되는지
+// 검증한다.
+func TestDropFlowGuard_LRUEvicts(t *testing.T) {
+	g := NewDropFlowGuard([]string{"ns"}, 2)
+	g.Admit("ns", "10.0.0.1", 1, "10.0.0.2", 1, "TCP")
+	g.Admit("ns", "10.0.0.1", 2, "10.0.0.2", 2, "TCP")
+	if g.Size() != 2 {
+		t.Fatalf("size=%d want 2", g.Size())
+	}
+	// 3 번째 신규 flow 추가 시 1 번째 evict.
+	g.Admit("ns", "10.0.0.1", 3, "10.0.0.2", 3, "TCP")
+	if g.Size() != 2 {
+		t.Errorf("size=%d want 2 (LRU cap 유지)", g.Size())
+	}
+}
+
+// TestDropFlowGuard_RevisitMovesToFront 는 동일 flow 의 재방문이 cache hit 으로 처리되어 LRU 의
+// 가장 앞으로 이동하는지 검증한다.
+func TestDropFlowGuard_RevisitMovesToFront(t *testing.T) {
+	g := NewDropFlowGuard([]string{"ns"}, 2)
+	g.Admit("ns", "10.0.0.1", 1, "10.0.0.2", 1, "TCP")
+	g.Admit("ns", "10.0.0.1", 2, "10.0.0.2", 2, "TCP")
+	// flow 1 재방문. evict 대상에서 벗어나야 함.
+	g.Admit("ns", "10.0.0.1", 1, "10.0.0.2", 1, "TCP")
+	// flow 3 추가 → flow 2 가 evict 되어야 함 (flow 1 은 최근 방문).
+	g.Admit("ns", "10.0.0.1", 3, "10.0.0.2", 3, "TCP")
+	// flow 1 다시 admit 시도 → 여전히 cache hit 이어야 함.
+	if !g.Admit("ns", "10.0.0.1", 1, "10.0.0.2", 1, "TCP") {
+		t.Errorf("재방문한 flow 가 cache hit 으로 admit 안 됨")
+	}
+	if g.Size() != 2 {
+		t.Errorf("size=%d want 2", g.Size())
+	}
+}

--- a/internal/netobs/metrics/metrics.go
+++ b/internal/netobs/metrics/metrics.go
@@ -114,6 +114,18 @@ var (
 		[]string{"node", "src_namespace", "src_workload", "traffic_scope", "direction", "dst_namespace", "dst_workload"},
 	)
 
+	// dropEventsFlow 는 #64 의 drop flow 5-tuple context 메트릭이다. 기존 dropEventsLabeled 가
+	// workload 단위로 emit 하는 반면 본 메트릭은 5-tuple (src_ip, src_port, dst_ip, dst_port,
+	// protocol) 라벨로 정확한 connection 식별을 제공한다. high cardinality 메트릭이라 emit 은
+	// namespace allow-list 와 top-N flow sampling 가드를 거친다 (다음 commit 에서 추가).
+	dropEventsFlow = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "netobs_drop_events_flow_total",
+			Help: "Drop events with 5-tuple flow context for #64. Emitted only for namespaces in NETOBS_DROP_FLOW_ALLOW_NAMESPACES and limited to top-N active flows for cardinality control. Use this metric to identify which specific connection's packets were dropped, complementing the workload-level netobs_drop_events_labeled_total.",
+		},
+		[]string{"node", "src_namespace", "src_workload", "traffic_scope", "direction", "drop_reason", "drop_category", "protocol", "src_ip", "src_port", "dst_ip", "dst_port"},
+	)
+
 	// pod-level 메트릭에는 dst_pod_uid 까지 노출된다. POD_FLOW_DST_UID_ALLOW_NAMESPACES 토글에 등록된
 	// namespace 의 dst Pod 흐름에 한해 값이 채워지고 그 외에는 빈 문자열로 emit 되어 cardinality 가
 	// 통제된다.
@@ -180,6 +192,7 @@ func Register(reg prometheus.Registerer) {
 		stageEventsLabeled,
 		stageLatencyLabeled,
 		dropEventsLabeled,
+		dropEventsFlow,
 		retransEventsLabeled,
 		podStageEventsLabeled,
 		podStageLatencyLabeled,
@@ -279,6 +292,22 @@ func Record(ev types.EnrichedEvent) {
 			label(ev.DropCategory),
 			dstNs,
 			dstWl,
+		).Inc()
+		// #64 의 5-tuple drop flow 메트릭은 별도 emit. 다음 commit 의 가드 (allow-list, LRU) 를
+		// 통과한 경우만 호출된다. 본 commit 단계에서는 가드 없이 모든 drop event 에 emit 한다.
+		dropEventsFlow.WithLabelValues(
+			label(ev.ObservedNodeLabel()),
+			label(ev.SourceNamespaceLabel()),
+			label(ev.SourceWorkloadLabel()),
+			label(ev.TrafficScope),
+			label(ev.Direction),
+			label(ev.DropReasonName),
+			label(ev.DropCategory),
+			label(ev.ProtocolText),
+			label(ev.SrcIPText),
+			strconv.FormatUint(uint64(ev.Raw.Sport), 10),
+			label(ev.DstIPText),
+			strconv.FormatUint(uint64(ev.Raw.Dport), 10),
 		).Inc()
 
 	case types.StageRetrans:

--- a/internal/netobs/metrics/metrics.go
+++ b/internal/netobs/metrics/metrics.go
@@ -133,7 +133,7 @@ var (
 			Name: "netobs_drop_events_flow_total",
 			Help: "Drop events with 5-tuple flow context for #64. Emitted only for namespaces in NETOBS_DROP_FLOW_ALLOW_NAMESPACES and limited to top-N active flows for cardinality control. Use this metric to identify which specific connection's packets were dropped, complementing the workload-level netobs_drop_events_labeled_total.",
 		},
-		[]string{"node", "src_namespace", "src_workload", "traffic_scope", "direction", "drop_reason", "drop_category", "protocol", "src_ip", "src_port", "dst_ip", "dst_port"},
+		[]string{"node", "src_namespace", "src_workload", "src_pod", "traffic_scope", "direction", "drop_reason", "drop_category", "protocol", "src_ip", "src_port", "dst_ip", "dst_port"},
 	)
 
 	// pod-level 메트릭에는 dst_pod_uid 까지 노출된다. POD_FLOW_DST_UID_ALLOW_NAMESPACES 토글에 등록된
@@ -316,6 +316,7 @@ func Record(ev types.EnrichedEvent) {
 				label(ev.ObservedNodeLabel()),
 				label(ev.SourceNamespaceLabel()),
 				label(ev.SourceWorkloadLabel()),
+				label(ev.Src.PodName),
 				label(ev.TrafficScope),
 				label(ev.Direction),
 				label(ev.DropReasonName),

--- a/internal/netobs/metrics/metrics.go
+++ b/internal/netobs/metrics/metrics.go
@@ -28,6 +28,16 @@ func init() {
 
 // SetPodMetricsEnabled은 pod-instance 레벨 메트릭 기록 여부를 전환하며, 반드시 Record가 호출되기
 // 전 (main startup 단계) 에 호출되어야 한다.
+// dropFlowGuard 는 netobs_drop_events_flow_total 의 emit cardinality 가드다. SetDropFlowGuard 가
+// startup 시점에 설정하지 않으면 nil 로 두어 emit 자체가 skip 된다 (#64 의 safe default).
+var dropFlowGuard *DropFlowGuard
+
+// SetDropFlowGuard 는 main agent 가 config 의 DropFlowAllowNamespaces 와 DropFlowMaxActive 로 가드를
+// 구성해 본 함수로 wire-up 한다. nil 을 전달하면 metric emit 이 명시적으로 disable 된다.
+func SetDropFlowGuard(g *DropFlowGuard) {
+	dropFlowGuard = g
+}
+
 func SetPodMetricsEnabled(v bool) {
 	podMetricsEnabled.Store(v)
 }
@@ -293,22 +303,30 @@ func Record(ev types.EnrichedEvent) {
 			dstNs,
 			dstWl,
 		).Inc()
-		// #64 의 5-tuple drop flow 메트릭은 별도 emit. 다음 commit 의 가드 (allow-list, LRU) 를
-		// 통과한 경우만 호출된다. 본 commit 단계에서는 가드 없이 모든 drop event 에 emit 한다.
-		dropEventsFlow.WithLabelValues(
-			label(ev.ObservedNodeLabel()),
-			label(ev.SourceNamespaceLabel()),
-			label(ev.SourceWorkloadLabel()),
-			label(ev.TrafficScope),
-			label(ev.Direction),
-			label(ev.DropReasonName),
-			label(ev.DropCategory),
-			label(ev.ProtocolText),
-			label(ev.SrcIPText),
-			strconv.FormatUint(uint64(ev.Raw.Sport), 10),
-			label(ev.DstIPText),
-			strconv.FormatUint(uint64(ev.Raw.Dport), 10),
-		).Inc()
+		// #64 의 5-tuple drop flow 메트릭은 namespace allow-list 와 top-N LRU 가드를 통과한 경우만
+		// emit 한다. guard 가 nil 이면 emit 자체가 skip 되어 cardinality 가 도입 전 수준 (0 series)
+		// 으로 유지된다.
+		if dropFlowGuard != nil && dropFlowGuard.Admit(
+			ev.SourceNamespaceLabel(),
+			ev.SrcIPText, ev.Raw.Sport,
+			ev.DstIPText, ev.Raw.Dport,
+			ev.ProtocolText,
+		) {
+			dropEventsFlow.WithLabelValues(
+				label(ev.ObservedNodeLabel()),
+				label(ev.SourceNamespaceLabel()),
+				label(ev.SourceWorkloadLabel()),
+				label(ev.TrafficScope),
+				label(ev.Direction),
+				label(ev.DropReasonName),
+				label(ev.DropCategory),
+				label(ev.ProtocolText),
+				label(ev.SrcIPText),
+				strconv.FormatUint(uint64(ev.Raw.Sport), 10),
+				label(ev.DstIPText),
+				strconv.FormatUint(uint64(ev.Raw.Dport), 10),
+			).Inc()
+		}
 
 	case types.StageRetrans:
 		retransEventsLabeled.WithLabelValues(

--- a/internal/netobs/types/event.go
+++ b/internal/netobs/types/event.go
@@ -39,7 +39,10 @@ type Event struct {
 	Dport uint16
 	Comm  [16]byte
 	Stage uint8
-	Pad   [3]byte
+	// Protocol 은 IP protocol number (IPPROTO_TCP=6, IPPROTO_UDP=17) 다. BPF 측 netobs_event 의
+	// pad[0] 자리에 추가되어 struct size 변경 없이 emit 된다.
+	Protocol uint8
+	Pad      [2]byte
 }
 
 type EnrichedEvent struct {
@@ -51,6 +54,9 @@ type EnrichedEvent struct {
 	ObservedNode   string
 	SrcIPText      string
 	DstIPText      string
+	// ProtocolText 는 IP protocol number 의 사람 읽을 수 있는 라벨이다. drop flow 5-tuple 메트릭의
+	// protocol 라벨로 사용된다. 알려지지 않은 protocol 은 "unknown" 으로 표시한다.
+	ProtocolText   string
 	Src            kube.PodIdentity
 	Dst            kube.PodIdentity
 	DropReasonName string
@@ -89,6 +95,19 @@ func StageName(stage uint8) string {
 	default:
 		return "unknown"
 	}
+}
+
+// IPProtocolName 은 IP protocol number 의 사람 읽을 수 있는 라벨을 반환한다. 첫 구현은 본 시리즈가
+// 다루는 TCP / UDP 두 protocol 만 매핑하고 그 외는 "unknown" 으로 두어 drop flow 메트릭의 카디널
+// 리티가 알려진 protocol 셋 안에서만 늘어나도록 한다.
+func IPProtocolName(p uint8) string {
+	switch p {
+	case 6:
+		return "TCP"
+	case 17:
+		return "UDP"
+	}
+	return "unknown"
 }
 
 func CommString(comm [16]byte) string {

--- a/internal/netobs/types/event_test.go
+++ b/internal/netobs/types/event_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestEventSize 는 BPF 측 netobs_event 와 Go 측 Event 구조체의 size 가 일치하는지 검증한다. BPF
+// ringbuf 가 raw byte 로 전송하므로 두 size 가 다르면 corrupted parsing 위험이 있다. BPF struct
+// 는 common.h 에서 8 byte 정렬 기준 96 byte 로 fixed 다.
+func TestEventSize(t *testing.T) {
+	const expected = 88
+	got := int(unsafe.Sizeof(Event{}))
+	if got != expected {
+		t.Errorf("Event size=%d want %d (BPF struct 와 layout 불일치)", got, expected)
+	}
+}
+
+// TestIPProtocolName 은 protocol 매핑 helper 가 TCP / UDP / unknown 을 정확히 식별하는지 검증한다.
+func TestIPProtocolName(t *testing.T) {
+	cases := []struct {
+		input uint8
+		want  string
+	}{
+		{6, "TCP"},
+		{17, "UDP"},
+		{0, "unknown"},
+		{1, "unknown"},  // ICMP
+		{47, "unknown"}, // GRE
+	}
+	for _, tc := range cases {
+		got := IPProtocolName(tc.input)
+		if got != tc.want {
+			t.Errorf("IPProtocolName(%d)=%q want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/netobs/types/event_test.go
+++ b/internal/netobs/types/event_test.go
@@ -7,7 +7,7 @@ import (
 
 // TestEventSize 는 BPF 측 netobs_event 와 Go 측 Event 구조체의 size 가 일치하는지 검증한다. BPF
 // ringbuf 가 raw byte 로 전송하므로 두 size 가 다르면 corrupted parsing 위험이 있다. BPF struct
-// 는 common.h 에서 8 byte 정렬 기준 96 byte 로 fixed 다.
+// 는 common.h 에서 정의되며 Go struct 와 size 가 88 byte 로 일치해야 한다.
 func TestEventSize(t *testing.T) {
 	const expected = 88
 	got := int(unsafe.Sizeof(Event{}))


### PR DESCRIPTION
## Summary

`netobs_drop_events_labeled_total`의 workload 단위 emit을 보완해 drop event의 정확한 5-tuple (src_ip, src_port, dst_ip, dst_port, protocol) connection 정보를 노출하는 `netobs_drop_events_flow_total` 메트릭과 burst 검출 alert를 추가한다. cardinality 위험은 namespace allow-list와 top-N LRU sampling 두 가드로 통제해 빈 allow-list가 기본 상태에서 emit 자체가 일어나지 않도록 한다. 이슈 #64의 수용 조건 3종을 모두 만족한다.

- 5-tuple 라벨이 `netobs_drop_events_flow_total` 메트릭에 노출된다
- `NetObsDropBurst` alert가 dev cluster의 합성 drop 시나리오에서 정상 발화 가능한 상태로 등록된다
- emit되는 series 수가 운영 환경 cluster에서 100k 이하로 유지된다 (LRU max 1024 × drop_reason 8종 = 8192 series per node 절대 상한)

## 설계 결정

- **BPF protocol 필드**: `netobs_event`와 `netobs_start_info` 구조체의 trailing padding 자리에 `__u8 protocol`을 추가해 struct size 변경 없이 emit한다. `BPF_CORE_READ_BITFIELD_PROBED(sk, sk_protocol)`로 kernel bitfield를 CO-RE로 안전하게 읽는다
- **IPv4 한정 가드**: `handle_kfree_skb_reason`에 `sk_family == NETOBS_AF_INET` 가드를 추가해 IPv4 외 family는 drop event emit 자체를 skip한다. 본 첫 구현은 IPv4 한정이며 IPv6는 별도 follow-up으로 분리한다
- **cardinality 가드**: `NETOBS_DROP_FLOW_ALLOW_NAMESPACES` env로 운영자가 진단 대상 namespace를 명시 등록해야 emit이 시작된다. 빈 allow-list 기본값이 모든 emit을 차단해 cardinality 안전 default를 보장한다. 활성 5-tuple flow는 `NETOBS_DROP_FLOW_MAX_ACTIVE` (기본 1024) 의 LRU sampling으로 cap된다
- **0.0.0.0 거부**: socket bind 전 drop의 saddr/daddr=0 5-tuple은 정확한 connection 식별이 불가하므로 LRU 등록 자체를 거부해 cache 공간 낭비를 차단한다
- **rate window 1분**: recording rule `netobs_drop_burst:rate1m`은 evaluation interval 30s와 rate window 1분으로 ServiceMonitor scrape interval 15s보다 충분히 길어 sample 부족으로 인한 빈 결과를 회피한다. short burst (수 초 단위) 는 1분 평균에서 희석되며 본 trade-off는 sustained burst 감지가 우선이라 채택한다

## 변경 내역

8 commit으로 분리해 review 단위를 명확히 둔다.

| Commit | 영역 | 핵심 |
|---|---|---|
| `0afb05c` | BPF | `netobs_event` 구조체에 protocol 필드 추가, `sk_protocol` bitfield 추출, IPv4 family 가드 |
| `1518471` | Go types | `Event.Protocol` 필드와 `EnrichedEvent.ProtocolText`, `IPProtocolName` helper. struct size 88 byte 회귀 가드 |
| `85851ae` | metrics | `netobs_drop_events_flow_total` CounterVec 신설 (13 라벨) |
| `1fe2851` | metrics | `DropFlowGuard` 라이브러리. namespace allow-list, top-N LRU sampling, 단위 테스트 4종 |
| `7b57d1d` | main | enricher가 `ProtocolText` 채우고 main agent가 `SetDropFlowGuard` wire-up |
| `120e318` | rule / alert | `netobs_drop_burst:rate1m` recording rule과 `NetObsDropBurst` alert |
| `5653408` | docs | `docs/netobs/drop-flow-analysis.md` 운영 가이드와 루트 README의 환경 변수 표 |
| `67eab96` | fix | 자체 점검 4 fix (`src_pod` 라벨 누락, rate window scrape 미스매치, hardcoded family 상수, 0.0.0.0 LRU 낭비) |

## 노출 메트릭과 alert

### 신규 메트릭

`netobs_drop_events_flow_total{node, src_namespace, src_workload, src_pod, traffic_scope, direction, drop_reason, drop_category, protocol, src_ip, src_port, dst_ip, dst_port}` counter다. 13 라벨로 5-tuple과 reason 분류를 모두 노출하지만 두 가드 (namespace allow-list, LRU) 로 emit이 통제되어 cardinality가 LRU max × drop_reason 수로 절대 상한이 묶인다.

### 신규 recording rule

`netobs_drop_burst:rate1m`이 동일 5-tuple의 drop rate를 1분 윈도우 평균으로 산출한다. `src_namespace, src_pod, src_ip, src_port, dst_ip, dst_port, protocol, drop_reason, drop_category` 9 라벨을 보존해 alert에서 정확한 connection 단위 식별이 가능하다.

### 신규 alert

`NetObsDropBurst` (severity warning) 가 `netobs_drop_burst:rate1m > 10`이 1분 지속 시 발화한다. annotation으로 5-tuple과 drop_reason을 노출하며 runbook은 `docs/netobs/drop-flow-analysis.md`의 4단계 워크플로 (5-tuple 추출, drop_category 분류, 동시 신호 cross-reference, workload-injector 합성 검증) 로 이어진다.

## 운영자 사용 절차

매니페스트 기반 운영에서는 DaemonSet의 env로 allow-list를 주입한다.

```sh
kubectl -n ebpf-project set env daemonset/netobs-agent \
  NETOBS_DROP_FLOW_ALLOW_NAMESPACES=my-app,correlation-stress
```

`NETOBS_DROP_FLOW_MAX_ACTIVE`도 동일 패턴으로 운영자가 cluster 규모에 맞춰 조정 가능하다. 상세 운영 절차는 [docs/netobs/drop-flow-analysis.md](docs/netobs/drop-flow-analysis.md) 에 정리되어 있다.

## Test plan

- [x] `go test -race ./internal/netobs/...` 통과 (BPF event size 88 byte 가드, protocol 매핑, DropFlowGuard 4 종 회귀 테스트)
- [x] `make generate` BPF 산출물 재컴파일 완료
- [x] `make check-prometheus-rules` 통과 (gpuobs 35 rules에 drop-flow recording 1종과 NetObsDropBurst alert 1종 포함)
- [x] `make build-netobs-agent` (root stray binary 없음, `./bin/` 산출)
- [x] `make image-build-netobs-agent` / `image-push-netobs-agent` (ghcr push 완료)
- [x] `make deploy-netobs-dev` 적용 후 daemonset rollout 정상, agent log의 `drop flow guard: disabled (NETOBS_DROP_FLOW_ALLOW_NAMESPACES empty)` 확인
- [x] `NETOBS_DROP_FLOW_ALLOW_NAMESPACES=correlation-stress` env override 적용 후 agent log의 `drop flow guard: allow_namespaces=[correlation-stress] max_active=1024` 확인
- [x] empty allow-list 기본 상태에서 `netobs_drop_events_flow_total` 0 series (cardinality 안전 default 검증)
- [x] `netobs-gpuobs.drop-flow.recording` 그룹이 cluster Prometheus에 정상 등록, `netobs_drop_burst:rate1m` recording rule 활성
- [x] `make deploy-netobs-prod` 적용 후 3 worker 노드 모두 rollout 정상, DaemonSet image가 `ghcr.io/inno-rnd-project/netobs-agent:0.4.8`로 swap
- [x] prod 적용 후 `cluster:network_health_score:5m` 0.98 정상 emit 지속
- [ ] 합성 drop burst 시나리오 (iptables 또는 conntrack 강제 reject) 로 `NetObsDropBurst` alert 실 발화는 별도 운영 검증으로 분리

## 비목표

- IPv6 5-tuple은 본 이슈 범위 밖이다. IPv4 한정 첫 구현이며 별도 이슈에서 다룬다
- conntrack table dump의 자동 통합은 본 이슈 범위 밖이다. drop reason 매핑까지가 책임이다
- drop 시점의 socket buffer 상태와 TCP 윈도우 추적은 본 이슈 범위 밖이다
- UDP / ICMP / GRE 등 TCP 외 protocol은 protocol 라벨에 `unknown`으로 emit되며 정밀 분류는 follow-up으로 분리한다

Closes #64
