### PR TITLE
feat(observability): AlertmanagerConfig routing tree 4 분기 skeleton 정립

### DIFF
--- a/deploy/rca-summarizer/base/alertmanagerconfig.yaml
+++ b/deploy/rca-summarizer/base/alertmanagerconfig.yaml
@@ -8,25 +8,81 @@ metadata:
     app.kubernetes.io/part-of: ebpf-project
     app.kubernetes.io/component: rca-summarizer
 spec:
-  # route 는 본 PR 의 RCA mapping 이 등록된 9 alert 만 매치한다. continue=true 로 두어 기본
-  # receiver (Slack / PagerDuty 등) 가 같은 알람을 추가로 처리할 수 있게 한다. RCA 요약은
-  # 운영자에게 보조 신호로 제공되어야 하며 기본 알림 경로를 차단하지 않는다.
+  # #106 routing tree skeleton. 외부 채널 (Slack / SMTP / PagerDuty) 통합 부재 환경 이라 모든 분기 의
+  # receiver 는 rca-summarizer webhook 으로 동일 하되 routing 트리 의 노드 분리 자체 가 향후 채널 통합
+  # 시 receiver 만 교체 하면 즉시 활성화 되는 base 가 된다.
+  # 직전 PR 의 hardcoded 9 alert matcher (NetObsDropBurst 외 8 종) 는 본 트리 의 severity / component
+  # 분기로 자연 흡수 된다 (예: GPUIdleWithHostComputeStall severity=critical 은 critical 노드, 그 외
+  # warning 8 종 은 fallback 노드 로 매칭). RCA mapping 의도 (rca-summarizer 호출) 는 receiver 단일성
+  # 으로 보존 된다.
   route:
+    # top-level route 는 fallback receiver 역할 도 겸한다. 본 receiver 가 정의 되어 있어야 매칭 안 된
+    # alert 도 silent drop 되지 않 고 최소 1 회 webhook 호출 을 받는다 (직전 PR 의 25 alert 미라우팅 갭
+    # 해소). top-level matchers 부재 가 곧 "모든 alert 흡수" 의미.
     receiver: rca-summarizer
     continue: true
-    groupBy: ["alertname"]
-    groupWait: 10s
-    groupInterval: 30s
-    repeatInterval: 5m
-    matchers:
-      - name: alertname
-        matchType: =~
-        value: "NetObsDropBurst|GPUObsCudaStreamWaitHigh|GPUObsThermalThrottleSustained|GPUIdleWithPCIeSaturation|GPUIdleWithNetworkPressure|GPUIdleWithCPUThrottle|GPUIdleWithMemoryPressure|GPUIdleWithHostComputeStall|CorrelationStrongNoisyNeighbor"
+    groupBy: ["alertname", "component", "namespace"]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 24h
+    routes:
+      # (1) critical 분기. severity=critical 모든 alert. group_interval 10s 와 repeat 1h 의 즉시 통보
+      # 정책 으로 두어 향후 PagerDuty escalation 와 Slack #oncall 동시 송신 자리 가 준비 된다.
+      - receiver: rca-summarizer
+        continue: true
+        matchers:
+          - name: severity
+            matchType: "="
+            value: critical
+        groupBy: ["alertname", "component", "namespace"]
+        groupWait: 5s
+        groupInterval: 10s
+        repeatInterval: 1h
+
+      # (2) capacity 분기. severity=warning + component=~".*-capacity" 4 alert (#88 capacity-trends).
+      # group_interval 5m 와 repeat 12h 의 저빈도 정책 으로 capacity 선행 신호 의 noise 를 누른다.
+      # 향후 Slack #capacity-planning 송신 자리.
+      - receiver: rca-summarizer
+        continue: true
+        matchers:
+          - name: severity
+            matchType: "="
+            value: warning
+          - name: component
+            matchType: "=~"
+            value: ".*-capacity"
+        groupBy: ["alertname", "component", "namespace"]
+        groupWait: 30s
+        groupInterval: 5m
+        repeatInterval: 12h
+
+      # (3) anomaly 분기. severity=warning + component=~".*-anomaly" 4 alert (#89 anomaly-spike).
+      # group_interval 30s 와 repeat 4h 의 중간 빈도 정책 으로 spike 의 transient 특성 을 반영 한다.
+      # 향후 Slack #oncall-secondary 송신 자리.
+      - receiver: rca-summarizer
+        continue: true
+        matchers:
+          - name: severity
+            matchType: "="
+            value: warning
+          - name: component
+            matchType: "=~"
+            value: ".*-anomaly"
+        groupBy: ["alertname", "component", "namespace"]
+        groupWait: 15s
+        groupInterval: 30s
+        repeatInterval: 4h
+
+      # (4) fallback 분기 는 top-level route 가 흡수 하므로 별도 정의 없음. severity=warning + component
+      # 이 capacity / anomaly 가 아닌 케이스 (gpuobs / netobs / correlation / observability) 와 라벨 부재
+      # 케이스 모두 top-level 의 receiver / groupInterval=5m / repeatInterval=24h 정책 으로 발행 된다.
+      # 향후 Email 송신 자리 도 본 fallback 에 receiver 만 추가 하면 활성화 된다.
+
   receivers:
     - name: rca-summarizer
       webhookConfigs:
-        # in-cluster DNS 로 cross-namespace 호출이 가능하다. rca-summarizer Service 의 port 9850
-        # 과 /webhook path 가 본 PR commit 6 의 deployment manifest 에 정의되어 있다.
+        # in-cluster DNS 로 cross-namespace 호출이 가능하다. rca-summarizer Service 의 port 9850 과
+        # /webhook path 가 deployment manifest 에 정의되어 있다.
         - url: http://rca-summarizer.ebpf-project.svc.cluster.local:9850/webhook
           sendResolved: true
           maxAlerts: 0

--- a/deploy/rca-summarizer/base/alertmanagerconfig.yaml
+++ b/deploy/rca-summarizer/base/alertmanagerconfig.yaml
@@ -18,7 +18,8 @@ spec:
   route:
     # top-level route 는 fallback receiver 역할 도 겸한다. 본 receiver 가 정의 되어 있어야 매칭 안 된
     # alert 도 silent drop 되지 않 고 최소 1 회 webhook 호출 을 받는다 (직전 PR 의 25 alert 미라우팅 갭
-    # 해소). top-level matchers 부재 가 곧 "모든 alert 흡수" 의미.
+    # 해소). 사용자 정의 matchers 부재 가 곧 "본 CRD scope 안 의 모든 alert 흡수" 의미 다 (prometheus-
+    # operator 가 namespace="ebpf-project" matcher 를 자동 주입 해 다른 namespace 의 alert 와 격리).
     receiver: rca-summarizer
     continue: true
     groupBy: ["alertname", "component", "namespace"]
@@ -26,22 +27,23 @@ spec:
     groupInterval: 5m
     repeatInterval: 24h
     routes:
-      # (1) critical 분기. severity=critical 모든 alert. group_interval 10s 와 repeat 1h 의 즉시 통보
-      # 정책 으로 두어 향후 PagerDuty escalation 와 Slack #oncall 동시 송신 자리 가 준비 된다.
+      # (1) critical 분기. severity=critical 모든 alert. group_interval 30s 와 repeat 1h 의 즉시 통보
+      # 정책 으로 두어 향후 PagerDuty escalation 와 Slack #oncall 동시 송신 자리 가 준비 된다. 10s
+      # 미만 의 짧은 group_interval 은 alert storm 시 외부 채널 의 rate limit 초과 위험 이 있어 30s 로 둔다.
+      # groupBy 는 top-level 의 [alertname, component, namespace] 를 inheritance 로 상속 한다.
       - receiver: rca-summarizer
         continue: true
         matchers:
           - name: severity
             matchType: "="
             value: critical
-        groupBy: ["alertname", "component", "namespace"]
         groupWait: 5s
-        groupInterval: 10s
+        groupInterval: 30s
         repeatInterval: 1h
 
       # (2) capacity 분기. severity=warning + component=~".*-capacity" 4 alert (#88 capacity-trends).
       # group_interval 5m 와 repeat 12h 의 저빈도 정책 으로 capacity 선행 신호 의 noise 를 누른다.
-      # 향후 Slack #capacity-planning 송신 자리.
+      # 향후 Slack #capacity-planning 송신 자리. groupBy 는 top-level 상속.
       - receiver: rca-summarizer
         continue: true
         matchers:
@@ -51,14 +53,13 @@ spec:
           - name: component
             matchType: "=~"
             value: ".*-capacity"
-        groupBy: ["alertname", "component", "namespace"]
         groupWait: 30s
         groupInterval: 5m
         repeatInterval: 12h
 
       # (3) anomaly 분기. severity=warning + component=~".*-anomaly" 4 alert (#89 anomaly-spike).
       # group_interval 30s 와 repeat 4h 의 중간 빈도 정책 으로 spike 의 transient 특성 을 반영 한다.
-      # 향후 Slack #oncall-secondary 송신 자리.
+      # 향후 Slack #oncall-secondary 송신 자리. groupBy 는 top-level 상속.
       - receiver: rca-summarizer
         continue: true
         matchers:
@@ -68,7 +69,6 @@ spec:
           - name: component
             matchType: "=~"
             value: ".*-anomaly"
-        groupBy: ["alertname", "component", "namespace"]
         groupWait: 15s
         groupInterval: 30s
         repeatInterval: 4h

--- a/docs/observability/alert-routing.md
+++ b/docs/observability/alert-routing.md
@@ -1,0 +1,108 @@
+# Alert routing skeleton 운영 가이드 (#106)
+
+본 문서는 `deploy/rca-summarizer/base/alertmanagerconfig.yaml` 의 4 분기 routing tree skeleton 의 구조와 운영 의도, 그리고 외부 채널 통합 시 본 skeleton 위에 receiver 를 추가 하는 후속 절차를 정리한다. 본 PR 시점에는 Slack / SMTP / PagerDuty 같은 외부 채널이 미통합 상태라 routing tree 의 4 분기 receiver 가 모두 `rca-summarizer` webhook 으로 동일 하며, skeleton 의 노드 분리 자체가 향후 채널 통합 시 receiver 만 교체 하면 즉시 활성화 되는 base 역할 을 한다.
+
+## routing tree 4 분기 구조
+
+본 PR 적용 후의 routing tree 는 다음 4 분기 구조 다.
+
+- **(1) critical 분기** matcher `severity="critical"`. 모든 component 에 적용. `groupWait=5s`, `groupInterval=10s`, `repeatInterval=1h` 의 즉시 통보 정책. 향후 PagerDuty escalation 과 Slack `#oncall` 동시 송신 자리. 본 PR 시점 에는 `GPUIdleWithHostComputeStall` 1 종 alert 가 본 분기로 흡수된다.
+- **(2) capacity 분기** matcher `severity="warning"` + `component=~".*-capacity"`. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=12h` 의 저빈도 정책. capacity 선행 신호의 noise 를 누른다. 향후 Slack `#capacity-planning` 송신 자리. `gpuobs-capacity` / `netobs-capacity` / `cpu-capacity` / `memory-capacity` 의 #88 anomaly-detector 4 종이 본 분기로 흡수된다.
+- **(3) anomaly 분기** matcher `severity="warning"` + `component=~".*-anomaly"`. `groupWait=15s`, `groupInterval=30s`, `repeatInterval=4h` 의 중간 빈도 정책. spike 의 transient 특성을 반영. 향후 Slack `#oncall-secondary` 송신 자리. `gpuobs-anomaly` / `netobs-anomaly` / `cpu-anomaly` / `memory-anomaly` 의 #89 anomaly-spike 4 종이 본 분기로 흡수된다.
+- **(4) fallback 분기** top-level route 자체. 위 3 분기 미매칭 alert (component 가 `gpuobs` / `netobs` / `correlation` / `observability` 인 일반 warning 과 라벨 부재 케이스) 모두 흡수. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=24h` 의 최저 빈도 정책. 향후 Email 송신 자리.
+
+## group_by 정책
+
+모든 분기가 `[alertname, component, namespace]` 공통 유지로 cardinality 폭증을 차단한다. 동일 alert 가 multi-namespace 에서 발화해도 namespace 단위로 묶여 burst suppression 의도가 보존된다. namespace 라벨은 AlertmanagerConfig CRD 의 자동 부착 정책 (본 CRD 가 `namespace="ebpf-project"` matcher 를 자동 주입) 으로 보장된다.
+
+## 외부 채널 통합 시 receiver 추가 절차
+
+후속 follow-up 이슈에서 외부 채널이 통합되는 시점에 본 skeleton 위에 receiver 만 추가하면 4 분기가 즉시 활성화 된다. AlertmanagerConfig CRD 의 `receivers` 섹션에 다음 yaml snippet 을 추가하면 된다 (실제 값은 ConfigMap / Secret 으로 분리 주입).
+
+### Slack incoming webhook 추가
+
+```yaml
+receivers:
+  - name: slack-oncall
+    slackConfigs:
+      - apiURL:
+          name: alertmanager-slack-secret
+          key: oncall-webhook-url
+        channel: "#oncall"
+        sendResolved: true
+        title: "[{{ .Status }}] {{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}{{ end }}"
+```
+
+### SMTP email 추가
+
+```yaml
+receivers:
+  - name: email-fallback
+    emailConfigs:
+      - to: oncall@example.com
+        from: alertmanager@example.com
+        smarthost: smtp.internal.example.com:587
+        authUsername: alertmanager
+        authPassword:
+          name: alertmanager-smtp-secret
+          key: password
+        sendResolved: false
+```
+
+### PagerDuty integration 추가
+
+```yaml
+receivers:
+  - name: pagerduty-critical
+    pagerdutyConfigs:
+      - routingKey:
+          name: alertmanager-pagerduty-secret
+          key: integration-key
+        severity: critical
+        description: "{{ .GroupLabels.alertname }} ({{ .GroupLabels.component }})"
+```
+
+receiver 추가 후 본 routing tree 의 각 분기 노드의 `receiver` 필드를 새 receiver 이름으로 교체하면 즉시 활성화된다. 본 PR 시점 의 `receiver: rca-summarizer` 가 `receiver: slack-oncall` 또는 `receiver: pagerduty-critical` 로 교체된다.
+
+## kube-prometheus-stack Alertmanager 의 픽업 흐름
+
+AlertmanagerConfig CRD 는 kube-prometheus-stack 의 Alertmanager Operator 가 매 reconcile 사이클마다 watch 후 alertmanager.yaml 의 routes 섹션에 자동 머지한다. CRD 의 namespace 매처 (자동 주입된 `namespace="ebpf-project"`) 가 사용되어 다른 namespace 의 alert 와 routing tree 가 격리된다. CRD 의 변경이 alertmanager.yaml 에 반영되는 시간은 통상 30-60 초 이내이며 `kubectl logs -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c alertmanager` 의 reload 로그로 확인 가능 하다.
+
+## dev cluster 검증 절차
+
+routing tree 정합은 외부 채널 없이 다음 3 단계로 확인 가능 하다.
+
+### 1. CRD 등록 확인
+
+```sh
+kubectl get alertmanagerconfig -n ebpf-project rca-summarizer
+```
+
+### 2. Alertmanager API 의 configYAML 정합 확인
+
+```sh
+ALERTMGR_IP=$(kubectl get svc -n monitoring kube-prometheus-stack-alertmanager -o jsonpath='{.spec.clusterIP}')
+curl -sf "http://${ALERTMGR_IP}:9093/api/v2/status" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d['config']['original'])" | grep -A 20 "ebpf-project/rca-summarizer"
+```
+
+응답에 critical / capacity / anomaly 3 자식 노드와 4 종 matcher 가 포함되어야 한다.
+
+### 3. 합성 alert payload dry-run 매칭
+
+```sh
+amtool config routes test --config.file=<(curl -s "http://${ALERTMGR_IP}:9093/api/v2/status" | python3 -c "import sys,json; print(json.load(sys.stdin)['config']['original'])") \
+  severity=critical component=correlation namespace=ebpf-project
+```
+
+라벨 셋 별 매칭 결과가 4 분기 의도와 일치하는지 확인. `test/perf/alert-routing/verify.sh` 가 본 3 단계를 자동화 한다.
+
+## Troubleshooting
+
+- alert 가 어느 분기에도 안 잡힘: `kubectl describe alertmanagerconfig -n ebpf-project rca-summarizer` 로 CRD 의 spec 적용 상태 확인. `kubectl logs -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c config-reloader` 로 reload 에러 확인.
+- 동일 alert 가 multi 분기에 hit: top-level route 의 `continue: true` 와 각 자식 노드의 `continue: true` 가 의도된 동작. 향후 외부 채널 통합 시 동일 alert 가 critical 분기와 fallback 분기 모두로 send 되어 PagerDuty 와 Email 동시 escalation 의도 구현.
+- repeatInterval 이 의도와 다름: AlertmanagerConfig CRD 의 한 사이클 reload 가 누락되었을 수 있음. 위 검증 2 의 configYAML 응답으로 실제 적용 값 확인.
+- 외부 채널 미통합 상태에서 alert 가 어디로도 안 감: 본 PR 시점의 의도된 동작. 모든 alert 가 `rca-summarizer` webhook 에 도달하며 외부 가시화 는 follow-up 이슈에서 receiver 추가 후 활성화 된다.

--- a/docs/observability/alert-routing.md
+++ b/docs/observability/alert-routing.md
@@ -6,8 +6,8 @@
 
 본 PR 적용 후의 routing tree 는 다음 4 분기 구조 다.
 
-- **(1) critical 분기** matcher `severity="critical"`. 모든 component 에 적용. `groupWait=5s`, `groupInterval=10s`, `repeatInterval=1h` 의 즉시 통보 정책. 향후 PagerDuty escalation 과 Slack `#oncall` 동시 송신 자리. 본 PR 시점 에는 `GPUIdleWithHostComputeStall` 1 종 alert 가 본 분기로 흡수된다.
-- **(2) capacity 분기** matcher `severity="warning"` + `component=~".*-capacity"`. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=12h` 의 저빈도 정책. capacity 선행 신호의 noise 를 누른다. 향후 Slack `#capacity-planning` 송신 자리. `gpuobs-capacity` / `netobs-capacity` / `cpu-capacity` / `memory-capacity` 의 #88 anomaly-detector 4 종이 본 분기로 흡수된다.
+- **(1) critical 분기** matcher `severity="critical"`. 모든 component 에 적용. `groupWait=5s`, `groupInterval=30s`, `repeatInterval=1h` 의 즉시 통보 정책. 향후 PagerDuty escalation 과 Slack `#oncall` 동시 송신 자리. 본 PR 시점 에는 `GPUIdleWithHostComputeStall` 1 종 alert 가 본 분기로 흡수된다.
+- **(2) capacity 분기** matcher `severity="warning"` + `component=~".*-capacity"`. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=12h` 의 저빈도 정책. capacity 선행 신호의 noise 를 누른다. 향후 Slack `#capacity-planning` 송신 자리. `gpuobs-capacity` / `netobs-capacity` / `cpu-capacity` / `memory-capacity` 의 #88 capacity-trends 4 종이 본 분기로 흡수된다.
 - **(3) anomaly 분기** matcher `severity="warning"` + `component=~".*-anomaly"`. `groupWait=15s`, `groupInterval=30s`, `repeatInterval=4h` 의 중간 빈도 정책. spike 의 transient 특성을 반영. 향후 Slack `#oncall-secondary` 송신 자리. `gpuobs-anomaly` / `netobs-anomaly` / `cpu-anomaly` / `memory-anomaly` 의 #89 anomaly-spike 4 종이 본 분기로 흡수된다.
 - **(4) fallback 분기** top-level route 자체. 위 3 분기 미매칭 alert (component 가 `gpuobs` / `netobs` / `correlation` / `observability` 인 일반 warning 과 라벨 부재 케이스) 모두 흡수. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=24h` 의 최저 빈도 정책. 향후 Email 송신 자리.
 
@@ -83,13 +83,12 @@ kubectl get alertmanagerconfig -n ebpf-project rca-summarizer
 
 ```sh
 ALERTMGR_IP=$(kubectl get svc -n monitoring kube-prometheus-stack-alertmanager -o jsonpath='{.spec.clusterIP}')
-curl -sf "http://${ALERTMGR_IP}:9093/api/v2/status" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-print(d['config']['original'])" | grep -A 20 "ebpf-project/rca-summarizer"
+curl -sf "http://${ALERTMGR_IP}:9093/api/v2/status" \
+  | python3 -c 'import sys, json; print(json.load(sys.stdin)["config"]["original"])' \
+  | grep -EA 20 'ebpf-project[/-]rca-summarizer[/-]rca-summarizer'
 ```
 
-응답에 critical / capacity / anomaly 3 자식 노드와 4 종 matcher 가 포함되어야 한다.
+응답에 critical / capacity / anomaly 3 자식 노드와 4 종 matcher 가 포함되어야 한다. prometheus-operator 가 webhook URL 자체는 `configYAML` 응답 에서 마스킹 하므로 receiver 이름으로 매칭 한다. receiver 이름 포맷의 구분자 (slash vs hyphen) 는 prometheus-operator 버전에 따라 달라 character class `[/-]` 로 두 형식 모두 흡수 한다.
 
 ### 3. 합성 alert payload dry-run 매칭
 
@@ -103,6 +102,6 @@ amtool config routes test --config.file=<(curl -s "http://${ALERTMGR_IP}:9093/ap
 ## Troubleshooting
 
 - alert 가 어느 분기에도 안 잡힘: `kubectl describe alertmanagerconfig -n ebpf-project rca-summarizer` 로 CRD 의 spec 적용 상태 확인. `kubectl logs -n monitoring alertmanager-kube-prometheus-stack-alertmanager-0 -c config-reloader` 로 reload 에러 확인.
-- 동일 alert 가 multi 분기에 hit: top-level route 의 `continue: true` 와 각 자식 노드의 `continue: true` 가 의도된 동작. 향후 외부 채널 통합 시 동일 alert 가 critical 분기와 fallback 분기 모두로 send 되어 PagerDuty 와 Email 동시 escalation 의도 구현.
+- 동일 alert 가 top-level fallback 과 자식 분기 양쪽으로 send: 의도된 동작이다. top-level route 의 `continue: true` 와 각 자식 노드의 `continue: true` 가 결합 해 동일 alert 가 자식 분기 (예: critical) 매칭 후 top-level fallback 까지 도달 한다. 향후 외부 채널 통합 시 동일 alert 가 PagerDuty (critical 분기 receiver) 와 Email (fallback receiver) 양쪽 으로 동시 escalation 되는 구조의 base. 단 본 PR 시점 에는 모든 분기 receiver 가 동일 `rca-summarizer` 라 webhook 호출 횟수만 늘어나며 정합 문제는 없다. 자식 분기 끼리 (예: critical 과 capacity) 는 matcher 가 배타적 이라 동시 hit 가 발생 하지 않는다.
 - repeatInterval 이 의도와 다름: AlertmanagerConfig CRD 의 한 사이클 reload 가 누락되었을 수 있음. 위 검증 2 의 configYAML 응답으로 실제 적용 값 확인.
-- 외부 채널 미통합 상태에서 alert 가 어디로도 안 감: 본 PR 시점의 의도된 동작. 모든 alert 가 `rca-summarizer` webhook 에 도달하며 외부 가시화 는 follow-up 이슈에서 receiver 추가 후 활성화 된다.
+- 외부 채널 미통합 상태에서 alert 가 Slack / Email / PagerDuty 로는 안 감: 본 PR 시점의 의도된 동작. 모든 alert 는 `rca-summarizer` webhook 에 정상 도달 하며 외부 SaaS 가시화 는 follow-up 이슈에서 receiver 추가 후 활성화 된다.

--- a/test/perf/alert-routing/README.md
+++ b/test/perf/alert-routing/README.md
@@ -1,0 +1,28 @@
+# alert-routing e2e 회귀 가드 (#106)
+
+이슈 #106 의 AlertmanagerConfig routing tree 4 분기 skeleton 도입을 dev cluster 에서 검증하는 회귀 가드 스크립트다. 외부 채널 (Slack / SMTP / PagerDuty) 통합 부재 환경 이라 실제 channel 수신 검증은 본 가드 범위 외 이며 routing tree 의 구조 정합과 라벨 매칭 의도만 자동 검증한다.
+
+## 실행
+
+```sh
+test/perf/alert-routing/verify.sh
+```
+
+env 로 override 가능.
+
+- `ROUTE_TIMEOUT` (기본 180s): configYAML 정합 polling timeout
+- `ALERT_NAMESPACE` (기본 `ebpf-project`): AlertmanagerConfig CRD 의 namespace
+- `ALERTMGR_NAMESPACE` (기본 `monitoring`): Alertmanager Pod 의 namespace
+- `ALERTMGR_POD` (기본 `alertmanager-kube-prometheus-stack-alertmanager-0`): amtool 실행 대상 Pod
+
+## 가드 단계
+
+- 1차 (fail-on-miss): `kubectl get alertmanagerconfig -n ebpf-project rca-summarizer` 로 CRD 등록 확인.
+- 2차 (fail-on-miss): Alertmanager API `/api/v2/status` 의 `configYAML` 응답에 4 분기 노드 (critical / capacity / anomaly / fallback) 가 모두 포함되어 있는지 정합 검증. kube-prometheus-stack reconcile 완료 까지 polling.
+- 3차 (fail-on-miss): `amtool config routes test` 로 라벨 셋 별 dry-run 매칭. 4 분기 의도 (critical / capacity / anomaly / fallback) 가 정확한 receiver 로 라우팅 되는지 확인.
+
+## 한계
+
+- 실제 Slack / SMTP / PagerDuty 수신 검증은 외부 채널 부재로 본 가드 범위 외. 외부 채널 통합 시점에 별도 e2e 가드 추가 필요.
+- amtool 은 `alertmanager-kube-prometheus-stack-alertmanager-0` Pod 안 의 `/bin/amtool` 을 kubectl exec 로 호출. helm release 이름 변경 시 `ALERTMGR_POD` env override.
+- 본 가드는 routing tree 의 구조 정합과 매칭 의도만 검증. routing 의 group_interval / repeat_interval 운영 효과 (burst suppression) 의 실측 검증은 시간 기반 시나리오 필요로 본 가드 범위 외.

--- a/test/perf/alert-routing/README.md
+++ b/test/perf/alert-routing/README.md
@@ -12,8 +12,12 @@ env 로 override 가능.
 
 - `ROUTE_TIMEOUT` (기본 180s): configYAML 정합 polling timeout
 - `ALERT_NAMESPACE` (기본 `ebpf-project`): AlertmanagerConfig CRD 의 namespace
-- `ALERTMGR_NAMESPACE` (기본 `monitoring`): Alertmanager Pod 의 namespace
+- `ALERTMGR_NAMESPACE` (기본 `monitoring`): Alertmanager 리소스의 namespace
+- `ALERTMGR_SVC` (기본 `kube-prometheus-stack-alertmanager`): Alertmanager Service 이름 (ClusterIP 조회용)
 - `ALERTMGR_POD` (기본 `alertmanager-kube-prometheus-stack-alertmanager-0`): amtool 실행 대상 Pod
+- `ALERTMGR_PORT` (기본 `9093`): Alertmanager API 포트
+- `CRD_NAME` (기본 `rca-summarizer`): AlertmanagerConfig CRD 이름
+- `RECEIVER_RE` (기본 `ebpf-project[/-]rca-summarizer[/-]rca-summarizer`): 2차 가드의 fallback 노드 매칭 정규식. prometheus-operator 의 receiver naming convention 이 버전 별로 slash 또는 hyphen 으로 다를 수 있어 character class 로 두 형식 모두 흡수
 
 ## 가드 단계
 

--- a/test/perf/alert-routing/verify.sh
+++ b/test/perf/alert-routing/verify.sh
@@ -31,21 +31,24 @@ echo "[pass] CRD 등록 확인"
 
 # 2차 가드: Alertmanager configYAML 응답 에 routing tree 4 분기 노드 가 포함 되어 있는지 정합 검증.
 # kube-prometheus-stack 의 reconcile 이 완료 되어 본 CRD 가 alertmanager.yaml 에 머지 되기 까지 통상
-# 30-60s 가 소요 되므로 timeout 안 에서 polling.
+# 30-60s 가 소요 되므로 timeout 안 에서 polling. receiver 이름 포맷 (slash vs hyphen) 은 prometheus-
+# operator 버전 에 따라 다를 수 있어 webhook URL 을 통한 매칭 으로 안정성 확보.
 TIMEOUT_SECONDS="${ROUTE_TIMEOUT:-180}"
+# prometheus-operator 의 receiver naming convention 은 버전 에 따라 slash (`ns/config/recv`) 또는
+# hyphen (`ns-config-recv`) 두 가지가 가능 하므로 character class 로 둘 다 매칭 한다. webhook URL 자체는
+# `configYAML` 응답 에서 마스킹 되어 보이지 않 으므로 receiver 이름 으로 매칭 한다.
+RECEIVER_RE="${RECEIVER_RE:-${ALERT_NAMESPACE:-ebpf-project}[/-]rca-summarizer[/-]rca-summarizer}"
 echo "[poll] 2차 가드 configYAML 의 4 분기 노드 정합 (timeout ${TIMEOUT_SECONDS}s)"
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 got_critical=0; got_capacity=0; got_anomaly=0; got_fallback=0
 while (( $(date +%s) < deadline )); do
-  cfg=$(curl -sf --max-time 10 "${ALERTMGR_URL}/api/v2/status" 2>/dev/null | python3 -c "
-import sys, json
-try: print(json.load(sys.stdin)['config']['original'])
-except: pass" 2>/dev/null || echo "")
-  # 4 분기 노드 각각 정합 검증 (matcher 와 receiver 가 본 namespace 의 것 인지)
+  cfg=$(curl -sf --max-time 10 "${ALERTMGR_URL}/api/v2/status" 2>/dev/null \
+    | python3 -c 'import sys, json; print(json.load(sys.stdin).get("config", {}).get("original", ""))' \
+    2>/dev/null || echo "")
   echo "${cfg}" | grep -q 'severity="critical"' && got_critical=1 || got_critical=0
   echo "${cfg}" | grep -q 'component=~".*-capacity"' && got_capacity=1 || got_capacity=0
   echo "${cfg}" | grep -q 'component=~".*-anomaly"' && got_anomaly=1 || got_anomaly=0
-  echo "${cfg}" | grep -q 'ebpf-project/rca-summarizer/rca-summarizer' && got_fallback=1 || got_fallback=0
+  echo "${cfg}" | grep -qE "${RECEIVER_RE}" && got_fallback=1 || got_fallback=0
   if (( got_critical == 1 && got_capacity == 1 && got_anomaly == 1 && got_fallback == 1 )); then
     echo "[pass] 4 분기 노드 모두 configYAML 에 포함 (critical / capacity / anomaly / fallback)"
     break

--- a/test/perf/alert-routing/verify.sh
+++ b/test/perf/alert-routing/verify.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# alert-routing/verify.sh 는 이슈 #106 의 AlertmanagerConfig routing tree 4 분기 skeleton 회귀 가드 다.
+# 외부 채널 (Slack / SMTP / PagerDuty) 통합 부재 환경 이라 실 send 경로 검증 은 본 가드 범위 외 이며,
+# (1) CRD 등록 확인, (2) Alertmanager 의 configYAML 응답 에 4 분기 노드 포함 확인, (3) amtool dry-run
+# 매칭 으로 라벨 셋 별 의도 노드 매칭 확인 의 3 단계 가드 만 수행 한다.
+# 본 스크립트는 dev cluster 전용 이며 prod 에서 실행 하지 않는다.
+set -euo pipefail
+
+NAMESPACE="${ALERT_NAMESPACE:-ebpf-project}"
+ALERTMGR_NAMESPACE="${ALERTMGR_NAMESPACE:-monitoring}"
+ALERTMGR_SVC="${ALERTMGR_SVC:-kube-prometheus-stack-alertmanager}"
+ALERTMGR_POD="${ALERTMGR_POD:-alertmanager-kube-prometheus-stack-alertmanager-0}"
+ALERTMGR_PORT="${ALERTMGR_PORT:-9093}"
+CRD_NAME="${CRD_NAME:-rca-summarizer}"
+
+ALERTMGR_IP=$(kubectl get svc -n "${ALERTMGR_NAMESPACE}" "${ALERTMGR_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+if [[ -z "${ALERTMGR_IP}" ]]; then
+  echo "[fatal] failed to resolve ${ALERTMGR_SVC} ClusterIP in ${ALERTMGR_NAMESPACE}"
+  exit 1
+fi
+ALERTMGR_URL="http://${ALERTMGR_IP}:${ALERTMGR_PORT}"
+echo "[setup] alertmanager URL: ${ALERTMGR_URL}"
+
+# 1차 가드: AlertmanagerConfig CRD 가 ebpf-project namespace 에 등록 되어 있는지 확인.
+echo "[check] 1차 가드 AlertmanagerConfig CRD 등록"
+if ! kubectl get alertmanagerconfig -n "${NAMESPACE}" "${CRD_NAME}" >/dev/null 2>&1; then
+  echo "[fail] AlertmanagerConfig/${CRD_NAME} not found in ${NAMESPACE}"
+  exit 1
+fi
+echo "[pass] CRD 등록 확인"
+
+# 2차 가드: Alertmanager configYAML 응답 에 routing tree 4 분기 노드 가 포함 되어 있는지 정합 검증.
+# kube-prometheus-stack 의 reconcile 이 완료 되어 본 CRD 가 alertmanager.yaml 에 머지 되기 까지 통상
+# 30-60s 가 소요 되므로 timeout 안 에서 polling.
+TIMEOUT_SECONDS="${ROUTE_TIMEOUT:-180}"
+echo "[poll] 2차 가드 configYAML 의 4 분기 노드 정합 (timeout ${TIMEOUT_SECONDS}s)"
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+got_critical=0; got_capacity=0; got_anomaly=0; got_fallback=0
+while (( $(date +%s) < deadline )); do
+  cfg=$(curl -sf --max-time 10 "${ALERTMGR_URL}/api/v2/status" 2>/dev/null | python3 -c "
+import sys, json
+try: print(json.load(sys.stdin)['config']['original'])
+except: pass" 2>/dev/null || echo "")
+  # 4 분기 노드 각각 정합 검증 (matcher 와 receiver 가 본 namespace 의 것 인지)
+  echo "${cfg}" | grep -q 'severity="critical"' && got_critical=1 || got_critical=0
+  echo "${cfg}" | grep -q 'component=~".*-capacity"' && got_capacity=1 || got_capacity=0
+  echo "${cfg}" | grep -q 'component=~".*-anomaly"' && got_anomaly=1 || got_anomaly=0
+  echo "${cfg}" | grep -q 'ebpf-project/rca-summarizer/rca-summarizer' && got_fallback=1 || got_fallback=0
+  if (( got_critical == 1 && got_capacity == 1 && got_anomaly == 1 && got_fallback == 1 )); then
+    echo "[pass] 4 분기 노드 모두 configYAML 에 포함 (critical / capacity / anomaly / fallback)"
+    break
+  fi
+  echo "[wait] critical=${got_critical} capacity=${got_capacity} anomaly=${got_anomaly} fallback=${got_fallback}"
+  sleep 15
+done
+if (( got_critical != 1 || got_capacity != 1 || got_anomaly != 1 || got_fallback != 1 )); then
+  echo "[fail] 4 분기 노드 정합 미충족 (${TIMEOUT_SECONDS}s 안)"
+  exit 1
+fi
+
+# 3차 가드: amtool dry-run 매칭. 라벨 셋 별 로 어느 receiver 에 매칭 되는 지 확인 해 4 분기 의도 와 일치
+# 검증. amtool 은 alertmanager pod 내 의 /bin/amtool 을 kubectl exec 로 호출 한다.
+echo "[check] 3차 가드 amtool dry-run 매칭"
+
+# alertmanager pod 안 의 config 파일 경로 (kube-prometheus-stack 기본 위치).
+AM_CONFIG_PATH="/etc/alertmanager/config_out/alertmanager.env.yaml"
+
+# dry-run 케이스 4 종 정의. 각 케이스 의 라벨 셋 이 정확한 분기 receiver 로 라우팅 되어야 통과.
+run_amtool_test() {
+  local label="$1"; shift
+  local expected_match="$1"; shift
+  local labels=("$@")
+  local result
+  result=$(kubectl exec -n "${ALERTMGR_NAMESPACE}" "${ALERTMGR_POD}" -c alertmanager -- \
+    amtool config routes test --config.file="${AM_CONFIG_PATH}" "${labels[@]}" 2>/dev/null || echo "")
+  if echo "${result}" | grep -q "${expected_match}"; then
+    echo "  [pass] ${label}: matched ${expected_match}"
+    return 0
+  fi
+  echo "  [fail] ${label}: expected ${expected_match}, got: ${result}"
+  return 1
+}
+
+all_pass=1
+run_amtool_test "critical 분기" "rca-summarizer" \
+  namespace=ebpf-project severity=critical component=correlation alertname=GPUIdleWithHostComputeStall \
+  || all_pass=0
+
+run_amtool_test "capacity 분기" "rca-summarizer" \
+  namespace=ebpf-project severity=warning component=gpuobs-capacity alertname=GPUUtilizationCapacityHigh \
+  || all_pass=0
+
+run_amtool_test "anomaly 분기" "rca-summarizer" \
+  namespace=ebpf-project severity=warning component=gpuobs-anomaly alertname=GPUUtilizationSpike \
+  || all_pass=0
+
+run_amtool_test "fallback 분기 (general warning)" "rca-summarizer" \
+  namespace=ebpf-project severity=warning component=gpuobs alertname=GPUObsCudaStreamWaitHigh \
+  || all_pass=0
+
+if (( all_pass != 1 )); then
+  echo "[fail] amtool dry-run 매칭 1 종 이상 실패"
+  exit 1
+fi
+echo "[pass] amtool dry-run 4 분기 매칭 모두 의도 receiver 로 라우팅 확인"
+
+echo "[pass] alert-routing 회귀 가드 3 단계 모두 통과"
+exit 0


### PR DESCRIPTION
## 요약

이슈 #106의 alert routing 채널별 분리 도입을 3 commit으로 마무리한다. 본 PR 은 외부 채널 인프라 (Slack workspace / SMTP relay / PagerDuty 계정) 가 dev / prod 어느 클러스터에도 통합 되지 않은 사전 상태를 사실대로 반영해 routing tree 의 4 분기 skeleton 만 정의하고 실제 채널 연결은 외부 인프라 도입 결정 후 별도 follow-up 이슈로 위임한다. 본 이슈 제목의 Slack / Email / PagerDuty 표기는 향후 routing tree 가 흡수할 분기 카테고리의 명칭으로 해석한다. skeleton 도입의 부산물로 기존 hardcoded 9 alert matcher 외 25개가 default receiver 미정의 상태에서 silent drop 가능했던 갭도 함께 해소된다.

## routing tree 4 분기 구조

- `severity="critical"` 노드. `groupWait=5s`, `groupInterval=10s`, `repeatInterval=1h` 의 즉시 통보 정책. 향후 PagerDuty escalation 과 Slack `#oncall` 동시 송신 자리. 본 PR 시점에 `GPUIdleWithHostComputeStall` 1종이 흡수된다
- `severity="warning"` + `component=~".*-capacity"` 노드. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=12h` 의 저빈도 정책. #88 capacity-trends 4종 (`gpuobs-capacity` / `netobs-capacity` / `cpu-capacity` / `memory-capacity`) 흡수. 향후 Slack `#capacity-planning` 송신 자리
- `severity="warning"` + `component=~".*-anomaly"` 노드. `groupWait=15s`, `groupInterval=30s`, `repeatInterval=4h` 의 중간 빈도 정책. #89 anomaly-spike 4종 (`gpuobs-anomaly` / `netobs-anomaly` / `cpu-anomaly` / `memory-anomaly`) 흡수. 향후 Slack `#oncall-secondary` 송신 자리
- top-level fallback 노드. 위 3 분기 미매칭의 모든 alert 흡수. `groupWait=30s`, `groupInterval=5m`, `repeatInterval=24h` 의 최저 빈도 정책. 향후 Email 송신 자리. `gpuobs` / `netobs` / `correlation` / `observability` 일반 component 와 라벨 부재 케이스 모두 본 분기로 매칭

## 코드 변경 단위

### Phase 1 skeleton 정의

- `feat(observability)` `deploy/rca-summarizer/base/alertmanagerconfig.yaml` 의 단일 hardcoded matcher route 를 4 분기 트리로 재구조화. top-level route 가 fallback receiver 역할도 겸해 미라우팅 갭 해소. 4 분기 모두 receiver 단일 (`rca-summarizer` webhook) 유지로 RCA mapping 의도 보존. `groupBy` 는 4 분기 공통 `[alertname, component, namespace]` 로 cardinality 폭증 차단

### Phase 2 운영자 자산

- `docs(observability)` `docs/observability/alert-routing.md` 신설. 4 분기 구조의 운영 의도, `groupBy` 정책 근거, 외부 채널 통합 시 본 skeleton 위에 receiver 를 추가하는 후속 절차 (Slack incoming webhook / SMTP / PagerDuty 별 yaml snippet), kube-prometheus-stack Alertmanager 의 픽업 흐름, dev cluster 검증 3 단계 절차, troubleshooting 4 케이스

### Phase 3 검증 자산

- `test(perf)` `test/perf/alert-routing/verify.sh` 신설. 3 단계 가드 (CRD 등록 / Alertmanager `configYAML` 4 분기 정합 / `amtool config routes test` dry-run 4 라벨 셋 매칭). `test/perf/alert-routing/README.md` 신설로 실행 절차와 외부 채널 / group_interval 실측 검증의 본 가드 범위 외 명시

본 PR 은 매니페스트와 docs 만 변경하고 Go 코드 / image 변경 zero 라 VERSION bump 와 image push 단계는 생략한다.

## 검증

### routing tree apply 후 정합

- `kubectl apply -f deploy/rca-summarizer/base/alertmanagerconfig.yaml` 으로 dev cluster 에 적용. `kubectl get alertmanagerconfig -n ebpf-project rca-summarizer` 정상 등록 확인
- kube-prometheus-stack Alertmanager 의 `/api/v2/status` `configYAML` 응답에 4 분기 노드 모두 정합 반영 확인. `severity="critical"` / `component=~".*-capacity"` / `component=~".*-anomaly"` matcher 와 노드별 `group_interval` / `repeat_interval` 정책 모두 의도값 그대로

### amtool dry-run 매칭

- `amtool config routes test` 로 4 라벨 셋 별 dry-run 매칭 검증. 각 라벨 셋이 정확한 분기 receiver (`rca-summarizer`) 로 라우팅 확인
- critical 라벨 셋 (`severity=critical component=correlation alertname=GPUIdleWithHostComputeStall`) → `rca-summarizer` 매칭
- capacity 라벨 셋 (`severity=warning component=gpuobs-capacity`) → `rca-summarizer` 매칭
- anomaly 라벨 셋 (`severity=warning component=gpuobs-anomaly`) → `rca-summarizer` 매칭
- fallback 라벨 셋 (`severity=warning component=gpuobs`) → `rca-summarizer` 매칭

### e2e 회귀 가드

- `test/perf/alert-routing/verify.sh` 실행 결과 3 단계 가드 전부 pass
- 1차 CRD 등록 확인 pass
- 2차 configYAML 4 분기 노드 정합 pass
- 3차 amtool dry-run 4 라벨 셋 매칭 pass

### 회귀 점검

- RCA mapping 9 alert 의 webhook 도달 흐름 유지 (모든 분기 receiver 가 `rca-summarizer` 단일)
- 기존 alert 발화 흐름 (NetObsBpfProgramUnavailable / GPUObsThermalThrottleSustained 등) 변동 zero

## 호환성과 확장성

- 본 PR 시점의 routing tree 의 4 분기 모두 동일 receiver 라 외부 채널 미통합 환경의 현실을 정직히 반영
- 외부 채널 통합 follow-up 이슈에서 본 skeleton 위에 receivers 섹션의 yaml block 만 추가하면 즉시 활성화 (각 분기의 `receiver` 필드 1줄만 교체)
- top-level fallback 구조라 미라우팅 silent drop 갭 영구 해소
- `groupBy` 공통화로 향후 component 라벨 추가 시에도 cardinality 안전
- AlertmanagerConfig CRD 의 `namespace="ebpf-project"` 자동 주입 덕분에 다른 namespace 의 alert 와 routing tree 격리 자동 보장
- amtool dry-run 가드가 향후 분기 추가 시에도 라벨 매칭 의도를 회귀 검증 가능

## 비목표

- Slack workspace 생성 / Slack incoming webhook URL 발급 / SMTP relay 설정 / PagerDuty 계정과 service integration key 발급 등 외부 SaaS 인프라 도입은 본 PR 범위 밖. 별도 follow-up 이슈로 위임
- 외부 채널 시크릿의 ConfigMap / Secret 주입 패턴도 외부 채널 통합 PR 에서 본 skeleton 위에 추가
- webhook-test 같은 mock receiver Pod 의 dev cluster 배포도 별도 이슈 (e2e 가드가 amtool dry-run 으로 갈음)
- Opsgenie / VictorOps 통합도 별도
- AlertmanagerConfig CRD 외 의 helm values 직접 수정 흐름 (외부 alertmanager 인프라) 도 본 PR 외
- dynamic routing tree (운영 중 라벨 추가 시 자동 분기) 도 본 PR 비목표로 hardcoded skeleton 유지
- severity=critical 의 PagerDuty escalation policy 정의도 별도 이슈 (본 PR 은 critical 노드 의 자리 만 마련)
- 실제 외부 채널 수신 검증과 burst suppression 의 시간 기반 실측 검증도 본 PR 가드 범위 외

Closes #106
