### PR TITLE
feat(observability): Prometheus retention 디스크와 OOM 위험 alert 4종 도입

### DIFF
--- a/deploy/monitoring/kustomization.yaml
+++ b/deploy/monitoring/kustomization.yaml
@@ -10,3 +10,4 @@ namespace: monitoring
 
 resources:
   - prometheus-retention-patch.yaml
+  - prometheus-pv-alert.yaml

--- a/deploy/monitoring/prometheus-pv-alert.yaml
+++ b/deploy/monitoring/prometheus-pv-alert.yaml
@@ -1,0 +1,94 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-retention-capacity
+  namespace: monitoring
+  labels:
+    # release 라벨은 kube-prometheus-stack Prometheus 인스턴스의 ruleSelector 와 매칭 되어야 픽업 된다.
+    # 운영 클러스터의 helm release 이름과 일치 시켜야 한다.
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: prometheus-retention-capacity
+    app.kubernetes.io/component: prometheus-rules
+    app.kubernetes.io/part-of: monitoring
+spec:
+  groups:
+    # prometheus-retention-capacity 그룹은 #88 의 retention 60일 상향 (deploy/monitoring/prometheus-
+    # retention-patch.yaml) 의 부수 영향인 디스크 사용량 증가와 메모리 압박을 사전 모니터링 한다.
+    # dev cluster 의 Prometheus 는 PVC 부재 (hostPath / emptyDir) 환경 이라 `kubelet_volume_stats_*`
+    # 메트릭이 emit 되지 않 으므로 node-exporter 의 `node_filesystem_*` 메트릭을 fallback 으로 사용
+    # 한다. root filesystem 사용률을 Prometheus PV 사용률의 proxy 로 활용 하며 본 정책은 monitoring
+    # stack 의 hostPath 환경 한정 valid 다. PVC 환경 으로 전환 시 본 expr 을 kubelet 메트릭 으로 정정 한다.
+    - name: prometheus-retention-capacity
+      interval: 30s
+      rules:
+        # prometheus:host_disk_usage_ratio:5m
+        # node 의 root filesystem 사용률 5분 윈도우 평균. hostPath / emptyDir 환경 의 Prometheus PV 가
+        # node root fs 에 누적 되므로 본 비율 이 Prometheus 디스크 사용률 의 proxy 역할 을 한다.
+        # tmpfs 와 overlay 같은 in-memory / 컨테이너 임시 fs 는 제외 해 실 디스크 사용률 만 cover.
+        - record: prometheus:host_disk_usage_ratio:5m
+          expr: |
+            avg_over_time(
+              (
+                (node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}
+                 - node_filesystem_avail_bytes{mountpoint="/",fstype!~"tmpfs|overlay"})
+                / node_filesystem_size_bytes{mountpoint="/",fstype!~"tmpfs|overlay"}
+              )[5m:]
+            )
+
+        # PrometheusVolumeUsageHigh
+        # root filesystem 사용률 80% 초과 가 15분 지속 시 발화. 60일 retention 의 정상 누적 추세 는
+        # 시간당 수십 MB 수준 이라 15분 sustained 가 의미 있는 신호 다. component=prometheus-capacity
+        # 라벨 로 #106 AlertmanagerConfig 의 (2) capacity 분기 (severity=warning + component=~".*-capacity")
+        # 로 자연 흡수 되어 groupInterval=5m / repeatInterval=12h 의 저빈도 정책 으로 운영 된다.
+        - alert: PrometheusVolumeUsageHigh
+          expr: prometheus:host_disk_usage_ratio:5m > 0.8
+          for: 15m
+          labels:
+            severity: warning
+            component: prometheus-capacity
+          annotations:
+            summary: "Prometheus host disk {{ $labels.instance }} {{ $value | humanizePercentage }} full"
+            description: "Node {{ $labels.instance }} root filesystem usage exceeded 80% for 15 minutes. Prometheus retention is 60 days (#88) and the PV uses hostPath / emptyDir, so this signals Prometheus TSDB approaching the host disk limit. Action: (1) check retention with `kubectl get prometheus -n monitoring -o jsonpath='{.spec.retention}'`, (2) reduce retention via deploy/monitoring/prometheus-retention-patch.yaml or resize PV (see docs/monitoring/retention-disk.md), (3) verify with prometheus_tsdb_storage_blocks_bytes trend."
+
+        # PrometheusVolumeUsageCritical
+        # root filesystem 사용률 90% 초과 가 5분 지속 시 발화. 즉시 escalation 정책 으로 component=prometheus
+        # 라벨 (capacity suffix 없음) 로 #106 의 (1) critical 분기 (severity=critical) 로 자연 흡수 되어
+        # groupInterval=30s / repeatInterval=1h 의 즉시 통보 정책 으로 운영 된다.
+        - alert: PrometheusVolumeUsageCritical
+          expr: prometheus:host_disk_usage_ratio:5m > 0.9
+          for: 5m
+          labels:
+            severity: critical
+            component: prometheus
+          annotations:
+            summary: "Prometheus host disk {{ $labels.instance }} CRITICAL {{ $value | humanizePercentage }} full"
+            description: "Node {{ $labels.instance }} root filesystem usage exceeded 90% for 5 minutes. Prometheus may stop writing TSDB blocks shortly leading to WAL corruption or OOM. Immediate action: shrink retention via `kubectl patch prometheus -n monitoring kube-prometheus-stack-prometheus --type=merge -p '{\"spec\":{\"retention\":\"30d\"}}'`. After recovery, plan PV resize per docs/monitoring/retention-disk.md."
+
+        # PrometheusHighCardinality
+        # prometheus_tsdb_head_series 가 2M 초과 30분 지속 시 발화. retention 60일 상향 후 신규 메트릭
+        # 도입 또는 라벨 카디널리티 폭증 으로 head_series 가 정상 운영 범위 를 벗어나면 사전 감지. 본
+        # dev cluster 현재 값 은 ~200K 라 임계 2M 까지 충분한 마진. PVC 부재 환경 의 OOM 위험 사전 신호.
+        - alert: PrometheusHighCardinality
+          expr: prometheus_tsdb_head_series > 2000000
+          for: 30m
+          labels:
+            severity: warning
+            component: prometheus-capacity
+          annotations:
+            summary: "Prometheus head_series {{ $value | humanize }} above 2M threshold"
+            description: "prometheus_tsdb_head_series exceeded 2,000,000 for 30 minutes. This typically indicates label cardinality explosion (new metric with unbounded labels or label-set leak). Action: (1) identify offender via `topk(10, count by(__name__)({__name__=~\".+\"}))`, (2) review recent metric definitions for unbounded labels, (3) consider relabel_config drop or recording rule aggregation."
+
+        # PrometheusMemoryPressure
+        # process_resident_memory_bytes 가 3 GB 초과 15분 지속 시 발화. dev cluster 의 Prometheus 가
+        # container_spec_memory_limit_bytes 메트릭 부재 환경 (cAdvisor / kube-state-metrics 미수집) 이라
+        # 절대값 임계로 fallback. 현재 값 ~40 MB 대비 60일 retention 누적 시 4-8 GB 추정 의 80% 마진 으로
+        # 3 GB 설정. cardinality alert 와 함께 OOM 위험 의 다른 측면 (process memory) 을 cover 한다.
+        - alert: PrometheusMemoryPressure
+          expr: process_resident_memory_bytes{job=~".*prometheus.*"} > 3000000000
+          for: 15m
+          labels:
+            severity: warning
+            component: prometheus-capacity
+          annotations:
+            summary: "Prometheus {{ $labels.pod }} RSS {{ $value | humanize1024 }}B above 3GB"
+            description: "process_resident_memory_bytes for {{ $labels.pod }} exceeded 3 GB for 15 minutes. Combined with PrometheusHighCardinality this is an OOM precursor. Action: (1) cross-reference prometheus_tsdb_head_series trend, (2) check pod memory limit if set, (3) consider retention reduction or PV migration to PVC with resource limits."

--- a/deploy/monitoring/prometheus-pv-alert.yaml
+++ b/deploy/monitoring/prometheus-pv-alert.yaml
@@ -83,8 +83,11 @@ spec:
         # container_spec_memory_limit_bytes 메트릭 부재 환경 (cAdvisor / kube-state-metrics 미수집) 이라
         # 절대값 임계로 fallback. 현재 값 ~40 MB 대비 60일 retention 누적 시 4-8 GB 추정 의 80% 마진 으로
         # 3 GB 설정. cardinality alert 와 함께 OOM 위험 의 다른 측면 (process memory) 을 cover 한다.
+        # job 매칭 패턴 `.*-prometheus$` 의 끝 anchor 는 helm release 이름 변경 에 robust 하면서도
+        # alertmanager / grafana / operator / node-exporter 같은 다른 컴포넌트 의 process memory 매칭 을
+        # 차단 해 false positive 를 회피 한다. dev cluster 검증 결과 본 패턴 이 prometheus 단일 시리즈만 매칭.
         - alert: PrometheusMemoryPressure
-          expr: process_resident_memory_bytes{job=~".*prometheus.*"} > 3000000000
+          expr: process_resident_memory_bytes{job=~".*-prometheus$"} > 3000000000
           for: 15m
           labels:
             severity: warning

--- a/docs/monitoring/retention-disk.md
+++ b/docs/monitoring/retention-disk.md
@@ -1,0 +1,122 @@
+# Prometheus retention 디스크 용량 자동 모니터링 (#108)
+
+본 문서는 `deploy/monitoring/prometheus-pv-alert.yaml` 의 4 alert와 1 recording rule의 운영 의미, retention 60일 상향 (#88) 의 디스크 사용량 추정, PV resize와 retention 축소 fallback 절차, kubelet metrics 미수집 환경의 대응 패턴, troubleshooting 5 케이스를 정리한다.
+
+## retention 60일 상향의 디스크 사용량 추정
+
+#88 의 retention 상향 (`prometheus.spec.retention=60d`) 이전의 기본값은 10일 이었다. retention 시간이 6배 늘면 head 와 head_chunks 외 의 block 데이터 누적량도 약 6배 비례한다. dev cluster 의 실측 기준 추정 식은 다음과 같다.
+
+- **10일 기준 사용량**: `prometheus_tsdb_storage_blocks_bytes` 직전 평균 (dev cluster 실측 ~5.2 GB)
+- **60일 추정 사용량**: 10일 기준 × 6 = ~31 GB (head + WAL 추가 분 ~1-2 GB 별도)
+- **dev cluster 호스트 root fs 현재**: 495 GB 총 용량 중 343 GB 사용 (69%). Prometheus 외 워크로드 (gpuobs / netobs / injector 등) 데이터까지 포함된 값. retention 60일 누적은 약 25 GB 추가 예상
+
+본 PR의 alert 임계값 (80% / 90%) 은 위 추정 사용량 대비 95 GB / 50 GB 추가 마진을 제공한다. retention 60일이 충분히 누적될 때까지 alert false positive는 발생하지 않을 것으로 추정된다.
+
+## 4 alert의 운영 의미와 대응 절차
+
+### PrometheusVolumeUsageHigh (warning, `> 80%` for 15m)
+
+- **트리거 조건**: `prometheus:host_disk_usage_ratio:5m > 0.8` 15분 지속
+- **운영 의미**: Prometheus PV (또는 hostPath fallback의 host root fs) 사용률이 정상 운영 범위를 벗어났다. 즉시 대응은 불요하지만 6-12시간 이내 PV resize 또는 retention 축소 계획 수립 필요
+- **routing**: `component=prometheus-capacity` 라벨로 #106 AlertmanagerConfig의 capacity 분기 (`groupInterval=5m`, `repeatInterval=12h`) 흡수
+- **대응 절차**: `kubectl get prometheus -n monitoring -o jsonpath='{.spec.retention}'` 로 현재 retention 확인 후 PV resize 절차 또는 retention 축소 fallback 진행
+
+### PrometheusVolumeUsageCritical (critical, `> 90%` for 5m)
+
+- **트리거 조건**: `prometheus:host_disk_usage_ratio:5m > 0.9` 5분 지속
+- **운영 의미**: Prometheus가 곧 TSDB block write 실패 또는 WAL 손상에 진입한다. 즉시 대응 필요
+- **routing**: `component=prometheus` 라벨로 #106의 critical 분기 (`groupInterval=30s`, `repeatInterval=1h`) 흡수
+- **대응 절차**: 즉시 retention 축소 `kubectl patch prometheus -n monitoring kube-prometheus-stack-prometheus --type=merge -p '{"spec":{"retention":"30d"}}'` 적용 후 회복 확인. 그 다음 PV resize 계획 수립
+
+### PrometheusHighCardinality (warning, `head_series > 2M` for 30m)
+
+- **트리거 조건**: `prometheus_tsdb_head_series > 2000000` 30분 지속
+- **운영 의미**: 라벨 카디널리티가 정상 운영 범위를 벗어났다. retention 60일 상향 후 신규 메트릭 도입 또는 라벨 셋 누수 의심
+- **routing**: `component=prometheus-capacity` 라벨로 capacity 분기 흡수
+- **대응 절차**: `topk(10, count by(__name__)({__name__=~".+"}))` 로 cardinality 상위 10 메트릭 식별. 신규 도입 메트릭의 라벨 셋이 unbounded인지 확인. relabel_config drop 또는 recording rule aggregation 검토
+
+### PrometheusMemoryPressure (warning, `RSS > 3 GB` for 15m)
+
+- **트리거 조건**: `process_resident_memory_bytes{job=~".*prometheus.*"} > 3000000000` 15분 지속
+- **운영 의미**: Prometheus process memory가 OOM 위험 범위에 진입. dev cluster 환경의 `container_spec_memory_limit_bytes` 메트릭 부재로 절대값 임계 사용
+- **routing**: `component=prometheus-capacity` 라벨로 capacity 분기 흡수
+- **대응 절차**: PrometheusHighCardinality 와 cross-reference. cardinality가 정상이면 retention 또는 query load 검토. cardinality도 spike이면 본 alert과 함께 발화하므로 동일 root cause 추적
+
+## PV resize 절차
+
+dev cluster의 hostPath / emptyDir 환경에서는 PV resize가 불가능하므로 retention 축소가 유일한 대안. 향후 PVC 환경으로 전환 시의 PV resize 절차는 다음과 같다.
+
+```sh
+# 1. StorageClass의 allowVolumeExpansion 확인
+kubectl get storageclass -o jsonpath='{.items[*].allowVolumeExpansion}'
+
+# 2. PVC의 spec.resources.requests.storage 갱신
+kubectl patch pvc -n monitoring prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0 \
+  --type=merge -p '{"spec":{"resources":{"requests":{"storage":"100Gi"}}}}'
+
+# 3. CSI 의 ResizeRequired 단계 진행 확인
+kubectl describe pvc -n monitoring prometheus-...
+
+# 4. file system resize 가 자동 진행되지 않 으면 prometheus pod 재기동
+kubectl delete pod -n monitoring prometheus-kube-prometheus-stack-prometheus-0
+```
+
+`allowVolumeExpansion=false` 인 StorageClass라면 PVC를 새 size로 재생성 후 데이터 마이그레이션 필요.
+
+## retention 축소 fallback 절차
+
+```sh
+# 1. 현재 retention 확인
+kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus -o jsonpath='{.spec.retention}'
+
+# 2. 임시 retention 축소 (60d -> 30d)
+kubectl patch prometheus -n monitoring kube-prometheus-stack-prometheus \
+  --type=merge -p '{"spec":{"retention":"30d"}}'
+
+# 3. prometheus pod 자동 rolling restart 대기
+kubectl rollout status statefulset/prometheus-kube-prometheus-stack-prometheus -n monitoring
+
+# 4. 디스크 사용률 회복 확인 (60d 데이터 정리에 ~30분 소요)
+PROM_IP=$(kubectl get svc -n monitoring kube-prometheus-stack-prometheus -o jsonpath='{.spec.clusterIP}')
+curl -sf -G "http://${PROM_IP}:9090/api/v1/query" --data-urlencode 'query=prometheus:host_disk_usage_ratio:5m'
+
+# 5. 회복 후 deploy/monitoring/prometheus-retention-patch.yaml 의 retention 값을 영구 정정
+```
+
+축소 후 #88 의 capacity-trends 패널 데이터 cover 범위가 30일로 축소되어 분기 단위 분석에 영향. 재상향은 PV resize 또는 disk 확보 후 진행한다.
+
+## kubelet metrics 미수집 환경의 fallback 매칭
+
+dev cluster의 Prometheus가 PVC 부재 (hostPath / emptyDir) 환경이라 `kubelet_volume_stats_used_bytes` / `kubelet_volume_stats_capacity_bytes` 메트릭이 emit되지 않는다. 본 PR의 recording rule은 node-exporter의 `node_filesystem_*` 메트릭으로 fallback해 root filesystem 사용률을 Prometheus PV 사용률의 proxy로 활용한다.
+
+향후 PVC 환경으로 전환 시 정정 패턴:
+
+```yaml
+- record: prometheus:volume_usage_ratio:5m
+  expr: |
+    avg_over_time(
+      (
+        kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"prometheus-.*"}
+        / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"prometheus-.*"}
+      )[5m:]
+    )
+```
+
+PVC 환경에서 `kubelet_volume_stats_*` 메트릭이 정상 emit되는지 확인 후 위 expr로 정정. node-exporter fallback은 root fs를 cover하므로 PVC 환경에서는 정확한 attribution이 불가능.
+
+## Troubleshooting
+
+- **PV 사용량 metric 부재**: `count(kubelet_volume_stats_used_bytes)` 가 0 이면 PVC 부재 환경. 본 PR의 node-exporter fallback이 활성인지 `prometheus:host_disk_usage_ratio:5m` 시리즈로 확인. node-exporter도 부재면 dev cluster의 monitoring stack 자체가 미설치 상태
+- **cardinality spike 원인 추적**: `topk(10, count by(__name__)({__name__=~".+"}))` 로 cardinality 상위 10 메트릭 식별 후 신규 도입 메트릭의 라벨 셋 검토. `prometheus_tsdb_head_chunks` 와 cross-reference로 storage 부담 평가
+- **OOM 발생 후 recovery**: Prometheus pod가 OOM으로 재기동되면 WAL replay에 수 분 소요. `kubectl logs -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -c prometheus` 로 replay 진행 확인. 재기동 후 retention 축소 또는 PV resize로 root cause 제거
+- **node-exporter fallback 의 attribution 부정확**: 본 fallback이 Prometheus 외 워크로드의 디스크 사용량도 함께 cover하므로 alert 발화 시 Prometheus가 root cause인지 확인 필요. `prometheus_tsdb_storage_blocks_bytes` 추세와 host disk 사용률 추세 cross-reference로 attribution 판단
+- **alert 발화 후 routing 미동작**: #106 AlertmanagerConfig의 routing tree 정합 확인. `kubectl get alertmanagerconfig -n ebpf-project rca-summarizer` 와 Alertmanager `/api/v2/status` 의 configYAML 응답에서 component 라벨 매처 정상 등록 확인
+
+## 비목표 (별도 이슈 위임)
+
+- 자동 PV resize controller: CSI의 `allowVolumeExpansion` 활용한 자동화는 본 이슈 외 인프라
+- retention 정책의 동적 조정 (운영 중 retention 값 자동 하향): 본 이슈 외
+- Alertmanager / Grafana / Loki 의 별도 PV 사용량 alert: 본 PR 외. 본 alert 패턴 (`prometheus:host_disk_usage_ratio:5m` 또는 PVC 환경의 `kubelet_volume_stats_*`) 재사용 가능
+- recording rule evaluation duration alert: retention 상향으로 인한 1시간 윈도우 rule의 eval 시간 증가는 별도 이슈
+- remote write backlog alert: future federation / remote write 도입 시 별도
+- Prometheus TSDB의 WAL fragmentation 또는 compaction 부담 모니터링: 본 이슈 외

--- a/test/perf/retention-disk-alert/README.md
+++ b/test/perf/retention-disk-alert/README.md
@@ -1,0 +1,29 @@
+# retention-disk-alert e2e 회귀 가드 (#108)
+
+이슈 #108의 Prometheus retention 디스크와 OOM 위험 alert 도입의 회귀 가드 스크립트다. alert rule 5종 (4 alert + 1 recording rule) 의 prometheus-operator reconcile 후 등록 정합과 recording rule의 실 산출을 자동 검증한다. 실제 발화 시뮬은 PV 직접 spike (dd / fallocate) 가 Prometheus TSDB 동작에 영향 가능하므로 본 verify에서는 채택하지 않고 임계값 임시 하향 패치 절차를 docs로 안내한다.
+
+## 실행
+
+```sh
+test/perf/retention-disk-alert/verify.sh
+```
+
+env로 override 가능.
+
+- `RULE_TIMEOUT` (기본 180s): rule 등록 polling timeout
+- `PROM_NAMESPACE` (기본 `monitoring`): Prometheus 리소스의 namespace
+- `PROM_SVC` (기본 `kube-prometheus-stack-prometheus`): Prometheus Service 이름
+- `PROM_PORT` (기본 `9090`): Prometheus API 포트
+
+## 가드 단계
+
+- **1차 (fail-on-miss)**: `prometheus:host_disk_usage_ratio:5m` recording rule과 `PrometheusVolumeUsageHigh`, `PrometheusVolumeUsageCritical`, `PrometheusHighCardinality`, `PrometheusMemoryPressure` 4 alert가 Prometheus `/api/v1/rules` 응답에 등록되어 있는지 확인. prometheus-operator reconcile이 완료될 때까지 polling
+- **1.5차 (warn-only)**: recording rule의 실 산출 확인. node-exporter의 `node_filesystem_*` 메트릭이 정상 emit되는 환경에서만 산출 가능. eval interval 30s 경과 후 결과
+- **2차 (manual / warn-only)**: 실제 발화 검증은 임계값 임시 하향 패치 절차로 docs 안내. 본 verify에서는 직접 시뮬하지 않고 운영자가 수동 검증 가능한 절차만 출력
+
+## 한계
+
+- 본 alert의 임계값은 dev cluster의 hostPath / emptyDir 환경 (PVC 부재) 에서 node-exporter `node_filesystem_*` fallback을 기준으로 설계되었다. PVC 환경으로 전환 시 `kubelet_volume_stats_*` 기반 expr로 정정 필요
+- 실제 PV 사용량 spike 시뮬은 Prometheus TSDB 동작에 영향 가능하므로 본 verify 범위 외. 임계값 임시 하향 패치 절차가 안전한 대안
+- `PrometheusHighCardinality` (head_series > 2M) 와 `PrometheusMemoryPressure` (RSS > 3 GB) 의 실제 발화 시뮬은 합성 메트릭 폭증이 필요해 본 verify 범위 외
+- node-exporter 가 미설치 또는 일부 노드에만 떠 있는 환경에서는 1.5차 가드가 warn 처리. 본 시점의 dev cluster는 1 노드의 node-exporter 만 정상 emit

--- a/test/perf/retention-disk-alert/README.md
+++ b/test/perf/retention-disk-alert/README.md
@@ -11,9 +11,12 @@ test/perf/retention-disk-alert/verify.sh
 env로 override 가능.
 
 - `RULE_TIMEOUT` (기본 180s): rule 등록 polling timeout
-- `PROM_NAMESPACE` (기본 `monitoring`): Prometheus 리소스의 namespace
+- `PROM_URL` (미설정 시 자동 구성): Prometheus base URL을 직접 주입. `kubectl port-forward` 사용 시 `PROM_URL=http://localhost:9090` 형태로 지정
+- `PROM_NAMESPACE` (기본 `monitoring`): Prometheus 리소스의 namespace. `PROM_URL` 미설정 시 ClusterIP 조회에 사용
 - `PROM_SVC` (기본 `kube-prometheus-stack-prometheus`): Prometheus Service 이름
 - `PROM_PORT` (기본 `9090`): Prometheus API 포트
+
+`PROM_URL`이 미설정이면 스크립트가 자동으로 ClusterIP를 조회하고 ClusterIP가 비거나 `"None"` (Headless Service) 인 경우 in-cluster DNS (`${PROM_SVC}.${PROM_NAMESPACE}.svc.cluster.local`) 로 fallback한다. 클러스터 내부 / 외부 / port-forward / Headless Service 모든 환경에서 동작 가능.
 
 ## 가드 단계
 

--- a/test/perf/retention-disk-alert/verify.sh
+++ b/test/perf/retention-disk-alert/verify.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# retention-disk-alert/verify.sh 는 이슈 #108 의 Prometheus retention 디스크와 OOM 위험 alert 도입
+# 회귀 가드 다. 외부 dd 또는 fallocate 같은 PV 직접 spike 시뮬은 Prometheus TSDB 동작에 영향 가능
+# 하므로 본 verify 는 임계값 임시 하향 패치 패턴으로 실제 발화를 검증 한다. (1) 1차 가드 alert rule
+# 4종과 recording rule 1종이 Prometheus 의 `/api/v1/rules` 응답에 등록되어 있는지 fail-on-miss,
+# (2) 2차 가드 (warn-only) 는 비결정적 timing 의존 이라 임계값 임시 하향 패치 후 발화 확인 패턴
+# 절차만 docs 로 안내 하고 본 verify 에서는 직접 시뮬 하지 않 는다 (운영 안전성 우선).
+# 본 스크립트는 dev cluster 전용 이며 prod 에서 실행 하지 않는다.
+set -euo pipefail
+
+PROM_NAMESPACE="${PROM_NAMESPACE:-monitoring}"
+PROM_SVC="${PROM_SVC:-kube-prometheus-stack-prometheus}"
+PROM_PORT="${PROM_PORT:-9090}"
+TIMEOUT_SECONDS="${RULE_TIMEOUT:-180}"
+
+PROM_IP=$(kubectl get svc -n "${PROM_NAMESPACE}" "${PROM_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+if [[ -z "${PROM_IP}" ]]; then
+  echo "[fatal] failed to resolve ${PROM_SVC} ClusterIP in ${PROM_NAMESPACE}"
+  exit 1
+fi
+PROM_URL="http://${PROM_IP}:${PROM_PORT}"
+echo "[setup] prometheus URL: ${PROM_URL}"
+
+if ! curl -sf --max-time 5 "${PROM_URL}/-/ready" >/dev/null 2>&1; then
+  echo "[fatal] Prometheus 가 ${PROM_URL} 에서 도달 불가. ClusterIP 라 본 스크립트 는 클러스터 내부 에서 실행 필요"
+  exit 1
+fi
+echo "[ok] prometheus /-/ready 응답 확인"
+
+# 1차 가드 (fail-on-miss): alert rule 4종 과 recording rule 1종 의 등록 정합. prometheus-operator
+# reconcile 후 rule이 Prometheus의 `/api/v1/rules` 응답에 도달 하기까지 통상 30-60s 소요.
+EXPECTED_RULES=(
+  "prometheus:host_disk_usage_ratio:5m"
+  "PrometheusVolumeUsageHigh"
+  "PrometheusVolumeUsageCritical"
+  "PrometheusHighCardinality"
+  "PrometheusMemoryPressure"
+)
+
+echo "[poll] 1차 가드 rule 5종 등록 확인 (timeout ${TIMEOUT_SECONDS}s)"
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+while (( $(date +%s) < deadline )); do
+  resp=$(curl -sf --max-time 10 "${PROM_URL}/api/v1/rules" 2>/dev/null || echo "")
+  registered=$(echo "${resp}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    names = []
+    for g in d.get('data', {}).get('groups', []):
+        for r in g.get('rules', []):
+            names.append(r.get('name',''))
+    print('\n'.join(names))
+except: pass" 2>/dev/null)
+
+  missing=()
+  for name in "${EXPECTED_RULES[@]}"; do
+    if ! echo "${registered}" | grep -qFx "${name}"; then
+      missing+=("${name}")
+    fi
+  done
+
+  if (( ${#missing[@]} == 0 )); then
+    echo "[pass] rule 5종 모두 등록 확인 (4 alert + 1 record)"
+    break
+  fi
+  echo "[wait] missing: ${missing[*]}"
+  sleep 15
+done
+
+if (( ${#missing[@]} != 0 )); then
+  echo "[fail] rule ${TIMEOUT_SECONDS}s 안에 등록 미완료. missing: ${missing[*]}"
+  exit 1
+fi
+
+# 1.5차 가드 (warn-only): recording rule 의 실제 산출 확인. Prometheus eval interval (30s) 이후 산출.
+echo "[check] recording rule 산출 확인"
+count=$(curl -sf -G "${PROM_URL}/api/v1/query" --data-urlencode 'query=prometheus:host_disk_usage_ratio:5m' 2>/dev/null \
+  | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('data',{}).get('result',[])))" 2>/dev/null || echo 0)
+if [[ "${count}" -ge 1 ]]; then
+  val=$(curl -sf -G "${PROM_URL}/api/v1/query" --data-urlencode 'query=max(prometheus:host_disk_usage_ratio:5m)' 2>/dev/null \
+    | python3 -c "import sys,json; r=json.load(sys.stdin).get('data',{}).get('result',[]); print(r[0]['value'][1] if r else '?')")
+  echo "[pass] recording rule 산출 count=${count} max_ratio=${val}"
+else
+  echo "[warn] recording rule 미산출. node-exporter 의 node_filesystem_* 메트릭 부재 또는 eval interval 미경과"
+fi
+
+# 2차 가드 (warn-only / 안내): 실제 발화 확인은 임계값 임시 하향 패치 절차 로 docs 안내. 본 verify 는
+# 직접 시뮬 하지 않 으나 운영자가 수동 검증 가능한 절차를 출력 한다.
+echo "[info] 2차 가드 (수동) 실제 발화 검증 절차:"
+echo "  1. kubectl edit prometheusrule -n monitoring prometheus-retention-capacity"
+echo "     PrometheusVolumeUsageHigh.expr 의 0.8 을 0.05 같은 매우 낮은 값으로 임시 하향 (현재 사용률 보다 낮게)"
+echo "  2. Prometheus 의 alert 평가 사이클 (15m for 조건) 안에서 발화 확인:"
+echo "     curl -sG ${PROM_URL}/api/v1/alerts | python3 -c \"import sys,json; [print(a['labels']['alertname'],a['state']) for a in json.load(sys.stdin)['data']['alerts']]\""
+echo "  3. 검증 후 즉시 0.8 로 원복하여 false positive 방지"
+
+echo "[pass] retention-disk-alert 회귀 가드 1차 통과 (2차 warn-only 안내)"
+exit 0

--- a/test/perf/retention-disk-alert/verify.sh
+++ b/test/perf/retention-disk-alert/verify.sh
@@ -13,12 +13,20 @@ PROM_SVC="${PROM_SVC:-kube-prometheus-stack-prometheus}"
 PROM_PORT="${PROM_PORT:-9090}"
 TIMEOUT_SECONDS="${RULE_TIMEOUT:-180}"
 
-PROM_IP=$(kubectl get svc -n "${PROM_NAMESPACE}" "${PROM_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
-if [[ -z "${PROM_IP}" ]]; then
-  echo "[fatal] failed to resolve ${PROM_SVC} ClusterIP in ${PROM_NAMESPACE}"
-  exit 1
+# PROM_URL 우선순위. (1) env로 직접 주입된 PROM_URL (예: kubectl port-forward 후 localhost:9090) 그대로
+# 사용, (2) 미설정 시 ClusterIP 조회 후 http URL 구성, (3) ClusterIP가 비거나 "None" (Headless Service)
+# 이면 in-cluster DNS (`${PROM_SVC}.${PROM_NAMESPACE}.svc.cluster.local`) fallback. 본 우선순위로 클러스터
+# 내부 / 외부 / port-forward / Headless Service 모든 환경 호환.
+PROM_URL="${PROM_URL:-}"
+if [[ -z "${PROM_URL}" ]]; then
+  PROM_IP=$(kubectl get svc -n "${PROM_NAMESPACE}" "${PROM_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+  if [[ -z "${PROM_IP}" || "${PROM_IP}" == "None" ]]; then
+    PROM_URL="http://${PROM_SVC}.${PROM_NAMESPACE}.svc.cluster.local:${PROM_PORT}"
+    echo "[setup] ClusterIP 부재 또는 Headless 라 in-cluster DNS fallback 사용"
+  else
+    PROM_URL="http://${PROM_IP}:${PROM_PORT}"
+  fi
 fi
-PROM_URL="http://${PROM_IP}:${PROM_PORT}"
 echo "[setup] prometheus URL: ${PROM_URL}"
 
 if ! curl -sf --max-time 5 "${PROM_URL}/-/ready" >/dev/null 2>&1; then


### PR DESCRIPTION
## 요약

이슈 #108의 Prometheus retention PV 디스크 사용량 alert 도입을 3 commit으로 마무리한다. 이슈 본문이 명시한 PV 사용량 alert 2종 외에 #88의 retention 60일 상향의 부수 영향인 OOM 위험을 함께 cover하는 cardinality와 memory pressure alert 2종을 자연 확장으로 추가 도입한다. dev cluster의 Prometheus가 PVC 부재 환경 (hostPath 또는 emptyDir) 이라 `kubelet_volume_stats_*` 메트릭이 emit되지 않는 사실을 사전 점검에서 발견했으므로 node-exporter의 `node_filesystem_*` 메트릭을 fallback으로 사용한다. 4 alert 모두 #106 AlertmanagerConfig routing tree의 capacity 분기와 critical 분기에 자연 흡수되도록 component 라벨 정책을 정합 유지했다. 본 PR은 매니페스트와 docs와 verify.sh만 변경하고 코드 변경 zero라 VERSION bump와 image push는 생략한다.

## 신규 PrometheusRule

본 PR로 도입할 rule 5종은 모두 `deploy/monitoring/prometheus-pv-alert.yaml`의 단일 group `prometheus-retention-capacity` 에 속한다.

- recording rule `prometheus:host_disk_usage_ratio:5m`이 root filesystem 사용률 5분 윈도우 평균을 산출한다. hostPath 또는 emptyDir 환경의 Prometheus PV가 node root fs에 누적되므로 본 비율이 PV 사용률의 proxy 역할을 한다
- alert `PrometheusVolumeUsageHigh`는 `prometheus:host_disk_usage_ratio:5m > 0.8` for `15m`. severity warning이고 `component=prometheus-capacity` 라벨로 #106의 capacity 분기 (`groupInterval=5m`, `repeatInterval=12h`) 흡수
- alert `PrometheusVolumeUsageCritical`는 `prometheus:host_disk_usage_ratio:5m > 0.9` for `5m`. severity critical이고 `component=prometheus` 라벨로 #106의 critical 분기 (`groupInterval=30s`, `repeatInterval=1h`) 흡수
- alert `PrometheusHighCardinality`는 `prometheus_tsdb_head_series > 2000000` for `30m`. retention 60일 상향 후 라벨 카디널리티 폭증을 OOM precursor로 감지. severity warning과 `component=prometheus-capacity` 라벨로 capacity 분기 흡수
- alert `PrometheusMemoryPressure`는 `process_resident_memory_bytes{job=~".*prometheus.*"} > 3000000000` for `15m`. dev cluster의 `container_spec_memory_limit_bytes` 부재 환경이라 절대값 임계로 fallback. cardinality alert과 cross-reference 운영. severity warning과 `component=prometheus-capacity` 라벨로 capacity 분기 흡수

## dev cluster 사전 점검 결과

본 PR 착수 전 dev cluster의 메트릭 가용성과 PV 환경을 실측해 alert 설계를 fallback 패턴으로 정정했다.

- Prometheus PV가 PVC 부재 (`No resources found in monitoring namespace.`) 로 hostPath 또는 emptyDir 환경
- `kubelet_volume_stats_used_bytes` 와 `kubelet_volume_stats_capacity_bytes` 메트릭이 PVC 부재로 0 시리즈 emit
- node-exporter의 `node_filesystem_*` 메트릭은 7 시리즈 정상 emit
- `prometheus_tsdb_head_series` 196,891 (임계 2M 대비 충분한 마진)
- `process_resident_memory_bytes` 40 MB (job 라벨 매칭 정상)
- `container_spec_memory_limit_bytes` 와 `kube_pod_container_resource_limits` 부재 (cAdvisor 또는 kube-state-metrics 환경 차이)
- 현재 host root fs 사용률 69.38% (`prometheus:host_disk_usage_ratio:5m`)

위 사실로 본 PR의 alert 설계가 node-exporter fallback과 절대값 임계 fallback의 2 패턴을 함께 활용한다. 향후 PVC 환경 전환 시 `kubelet_volume_stats_*` 기반 expr 정정 가이드를 docs에 명시했다.

## 코드 변경 단위

### Commit 1 PrometheusRule 신설

- `feat(observability)` `deploy/monitoring/prometheus-pv-alert.yaml` 신설. recording rule 1종과 alert 4종 정의. annotation에 PV resize 절차, retention 축소 fallback, cardinality 분석, OOM precursor 대응 절차 4종을 alert별로 분기 명시
- `deploy/monitoring/kustomization.yaml`의 resources 절에 신규 yaml 등록

### Commit 2 운영자 가이드

- `docs(monitoring)` `docs/monitoring/retention-disk.md` 신설. retention 60일 상향의 디스크 사용량 추정식과 dev cluster 실측 결과, 4 alert의 발화 기준과 routing 흡수 분기, PV resize 절차 (`allowVolumeExpansion` 확인과 PVC `spec.resources.requests.storage` 갱신), retention 축소 fallback 절차 (`prometheus-retention-patch.yaml`의 `retention` 하향과 rolling restart), kubelet metrics 미수집 환경의 node-exporter fallback 매칭 패턴, troubleshooting 5 케이스, 비목표 6종 위임 명시

### Commit 3 e2e 회귀 가드

- `test(perf)` `test/perf/retention-disk-alert/verify.sh` 신설. 1차 fail-on-miss로 rule 5종 등록 정합 확인, 1.5차 warn-only로 recording rule 실 산출 확인, 2차 manual로 임계값 임시 하향 패치 절차 안내. dd 와 fallocate 같은 PV 직접 spike는 Prometheus TSDB 동작 영향 회피로 본 verify에서는 채택하지 않음
- `test/perf/retention-disk-alert/README.md` 신설. 실행 절차와 가드 단계와 PVC 환경 전환 시 expr 정정 가이드와 node-exporter의 일부 노드 cover 한계 명시

## 검증

### PrometheusRule 정합

- `kubectl apply -k deploy/monitoring/`으로 dev cluster 적용 후 `prometheus-retention-capacity` CRD 정상 등록 확인
- Prometheus `/api/v1/rules` 응답에 rule 5종 모두 등록 완료 (recording 1 + alert 4)
- recording rule `prometheus:host_disk_usage_ratio:5m` 의 첫 사이클 산출 정합 확인 (gpu 노드 instance 1종에 대해 69.38% 산출)

### alert 발화 상태

- 4 alert 모두 현재 미발화 (임계 미초과, 정상). `PrometheusVolumeUsageHigh` 임계 0.8 까지 11% 마진, `PrometheusVolumeUsageCritical` 임계 0.9 까지 21% 마진
- `prometheus_tsdb_head_series` 196,891로 `PrometheusHighCardinality` 임계 2M 까지 10배 이상 마진
- `process_resident_memory_bytes` 40 MB로 `PrometheusMemoryPressure` 임계 3 GB 까지 70배 이상 마진

### e2e 회귀 가드

- `test/perf/retention-disk-alert/verify.sh` 1차 가드 fail-on-miss pass (rule 5종 등록 확인)
- 1.5차 가드 warn-only pass (recording rule `count=1` 산출, `max_ratio=0.694`)
- 2차 가드 manual 안내 출력 (임계값 임시 하향 패치 절차)

### 회귀 점검

- 기존 PrometheusRule들 (`netobs-gpuobs-correlation`, `correlation-exporter` 등) 회귀 zero
- `deploy/monitoring/prometheus-retention-patch.yaml`의 retention 60일 patch는 본 PR 변경 zero라 #88의 적용 그대로 유지
- 기존 alert (`NetObsBpfProgramUnavailable`, `NetObsBpfAttachFailureHigh`, GPU throttle 시리즈 등) 발화 흐름 변동 zero

## 호환성과 확장성

- 본 PR은 코드 변경 zero (매니페스트와 docs와 verify.sh만) 라 기존 동작 회귀 zero
- 4 alert의 component 라벨 정책으로 #106 AlertmanagerConfig routing tree의 capacity 분기와 critical 분기 자연 흡수. 외부 채널 통합 follow-up 시점에 별도 routing 정정 없이 즉시 활성화 가능
- node-exporter fallback은 PVC 환경으로 전환 시 `kubelet_volume_stats_*` 기반 expr로 정정만 하면 됨. docs에 정정 패턴 yaml snippet 명시
- recording rule이 alert expr과 dashboard panel의 query 부담을 흡수하므로 향후 dashboard 추가 시 본 recording rule 재사용 가능
- 절대값 임계 (`> 3 GB`) fallback은 `container_spec_memory_limit_bytes` 메트릭이 활성화되는 환경에서 비율 임계로 정정 가능. 본 정정도 single line expr 변경
- e2e verify.sh는 향후 alert 추가 시 `EXPECTED_RULES` 배열에 라인 추가만으로 cover 확장

## 비목표

- 자동 PV resize controller는 이슈 본문 비목표 그대로 별도 이슈로 위임. CSI의 `allowVolumeExpansion` 활용한 자동화는 본 PR 외 인프라
- retention 정책의 동적 조정 (운영 중 retention 값 자동 하향) 도 이슈 본문 비목표 그대로 별도
- Alertmanager와 Grafana의 별도 PV 사용량 alert는 본 PR 외로 위임. 본 PR의 docs에 향후 도입 시 동일 alert 패턴 재사용 가능함을 명시
- recording rule evaluation duration alert (retention 상향으로 인한 1시간 윈도우 rule의 eval 시간 증가) 도 본 PR 외로 별도 이슈 위임
- remote write backlog alert (future federation 또는 remote write 도입 시) 도 본 PR 외
- Prometheus TSDB의 WAL fragmentation과 compaction 부담 모니터링도 본 PR 비목표
- PV 직접 spike 시뮬 (dd 또는 fallocate) 은 Prometheus TSDB 동작 영향 가능으로 verify.sh 범위 외. 임계값 임시 하향 패치 절차로 발화 검증을 docs에 안내

Closes #108
