### PR TITLE
feat(injector): LoadScenario manifest 예제 8종 신설

### DIFF
--- a/deploy/injector/examples/concurrency-allow-scenario.yaml
+++ b/deploy/injector/examples/concurrency-allow-scenario.yaml
@@ -1,0 +1,21 @@
+# concurrency-allow-scenario.yaml 은 #118 LoadScenario manifest 예제 3 concurrencyPolicy 중
+# Allow 정책 의 base 다. concurrencyPolicy: Allow 는 동일 target Pod 에 대한 동시 injection 을
+# 허용 하는 의도 였 으나 internal/injector/safety/safety.go 의 AcquireLock 이 ConfigMap annotation
+# lease 로 동일 target 의 동시 lock 을 차단 하므로 사실상 Allow 는 lease 충돌 시 conflict error
+# 반환 동작 을 의미 한다. 운영자는 동일 target 의 단발 부하 만 의도 할 때 본 정책 을 채택 한다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-concurrency-allow
+  namespace: ebpf-project
+spec:
+  schedule: "@every 10m"
+  kind: cpu
+  duration: 1m
+  intensity: 500m
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  # Allow: 동일 target 에 대한 동시 injection 시도 시 lease 차단 으로 conflict error.
+  concurrencyPolicy: Allow
+  maxFailures: 3

--- a/deploy/injector/examples/concurrency-forbid-scenario.yaml
+++ b/deploy/injector/examples/concurrency-forbid-scenario.yaml
@@ -1,0 +1,20 @@
+# concurrency-forbid-scenario.yaml 은 #118 LoadScenario manifest 예제 3 concurrencyPolicy 중
+# Forbid 정책 의 base 다. controller 가 기존 run 이 진행 중 인 동안 다음 schedule trigger 를
+# skip (consecutiveFailures 미증가) 한다. duration 이 schedule 주기 보다 길 가능성 이 있 어 lease
+# 보호 가 우선 일 때 적합 하다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-concurrency-forbid
+  namespace: ebpf-project
+spec:
+  schedule: "@every 5m"
+  kind: cpu
+  duration: 3m
+  intensity: 500m
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  # Forbid: 기존 run 보유 시 다음 trigger skip. consecutiveFailures 미증가.
+  concurrencyPolicy: Forbid
+  maxFailures: 3

--- a/deploy/injector/examples/concurrency-replace-scenario.yaml
+++ b/deploy/injector/examples/concurrency-replace-scenario.yaml
@@ -1,0 +1,21 @@
+# concurrency-replace-scenario.yaml 은 #118 LoadScenario manifest 예제 3 concurrencyPolicy 중
+# Replace 정책 의 base 다. controller 가 기존 lease 를 forceReleaseLease 로 해제 한 후 새 run 을
+# 즉시 trigger 한다. 최신 부하 시나리오 가 항상 active 한 상태 를 유지 하고 싶을 때 적합 하다.
+# 다만 진행 중인 부하 가 중간 에 끊겨 stale stress Pod 가 정리 되지 않 을 위험 이 있어 finalizer
+# 와 lifecycle (#102 controller 의 cleanup 흐름) 정상 동작 환경 에서만 권장 한다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-concurrency-replace
+  namespace: ebpf-project
+spec:
+  schedule: "@every 5m"
+  kind: cpu
+  duration: 4m
+  intensity: 500m
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  # Replace: 기존 lease 강제 해제 후 신규 run trigger.
+  concurrencyPolicy: Replace
+  maxFailures: 3

--- a/deploy/injector/examples/cpu-stress-scenario.yaml
+++ b/deploy/injector/examples/cpu-stress-scenario.yaml
@@ -1,0 +1,28 @@
+# cpu-stress-scenario.yaml 은 #118 LoadScenario manifest 예제 4 kind 중 cpu 부하 의 base 다.
+# 운영자가 신규 LoadScenario CR 작성 시 본 yaml 을 복사 후 targetRef 와 schedule 만 운영 환경에
+# 맞춰 정정하면 즉시 적용 가능 하다.
+#
+# spec 필드 의미:
+#   schedule: cron 표현식 (`@every 10m` 은 매 10분 1회). robfig/cron v3 의 standard parser.
+#   kind: cpu / memory / network / gpu 의 enum. 본 예제는 cpu 부하 의도.
+#   duration: 단일 run 의 지속 시간. metav1.Duration 형식 (예: "2m", "30s", "1h").
+#   intensity: cpu 의 경우 milliCPU 단위 (예: "500m" 은 0.5 core). 안전 상한 4000m (= 4 core,
+#     internal/injector/safety/safety.go 의 IntensityLimits 정의).
+#   targetRef: 부하를 인가할 대상 Pod 의 namespace 와 name. 본 예제 는 correlation-stress/victim
+#     을 default 로 두며 다른 namespace 의 Pod 는 운영자가 명시 정정 한다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-cpu-stress
+  namespace: ebpf-project
+spec:
+  schedule: "@every 10m"
+  kind: cpu
+  duration: 2m
+  # 800m = 0.8 core. dev cluster 의 victim Pod 1 core request 의 80% 점유 의도.
+  intensity: 800m
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  concurrencyPolicy: Forbid
+  maxFailures: 3

--- a/deploy/injector/examples/gpu-load-scenario.yaml
+++ b/deploy/injector/examples/gpu-load-scenario.yaml
@@ -1,0 +1,25 @@
+# gpu-load-scenario.yaml 은 #118 LoadScenario manifest 예제 4 kind 중 gpu 부하 의 base 다.
+# nvidia/cuda 의 vectorAdd sample 무한 반복으로 GPU 부하 를 발생시킨다. dev cluster 의 RTX 3090
+# 단일 GPU 환경 에 정합 하며 multi-GPU 점유 는 본 이슈 외 (#102 비목표 그대로).
+#
+# spec 필드 의미:
+#   intensity: gpu 의 경우 device 수. 안전 상한 "1" (multi-GPU 점유 follow-up). 본 예제 는 단일 GPU.
+#   targetRef: GPU 워크로드 Pod 의 namespace 와 name. dev cluster 의 pytorch-conv2d-bench 같은
+#     bench Pod 가 default 후보 이지만 ad-hoc bench Pod 라 본 예제 의 targetRef 는 운영자가 실제
+#     배포된 GPU Pod 의 namespace 와 name 으로 명시 정정 한다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-gpu-load
+  namespace: ebpf-project
+spec:
+  schedule: "@every 1h"
+  kind: gpu
+  duration: 5m
+  # GPU 단일 device 점유.
+  intensity: "1"
+  targetRef:
+    namespace: ebpf-project
+    name: pytorch-conv2d-bench
+  concurrencyPolicy: Forbid
+  maxFailures: 3

--- a/deploy/injector/examples/memory-pressure-scenario.yaml
+++ b/deploy/injector/examples/memory-pressure-scenario.yaml
@@ -1,0 +1,23 @@
+# memory-pressure-scenario.yaml 은 #118 LoadScenario manifest 예제 4 kind 중 memory 부하 의 base 다.
+# stress-ng --vm 으로 victim Pod 에 메모리 압박 을 발생시켜 OOM 인접 상황의 z-score spike alert 를
+# 자극 한다.
+#
+# spec 필드 의미:
+#   intensity: memory 의 경우 bytes 단위 (K8s resource.Quantity 규약). 예: "512Mi" 는 512 MiB.
+#     binary prefix (Ki / Mi / Gi) 와 decimal prefix (K / M / G) 모두 지원. 안전 상한 2Gi.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-memory-pressure
+  namespace: ebpf-project
+spec:
+  schedule: "@every 30m"
+  kind: memory
+  duration: 3m
+  # 1Gi = victim Pod 메모리 limit 2Gi 의 50% 점유 의도. OOM 직전 단계 의 메모리 압박 신호 자극.
+  intensity: 1Gi
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  concurrencyPolicy: Forbid
+  maxFailures: 3

--- a/deploy/injector/examples/network-load-scenario.yaml
+++ b/deploy/injector/examples/network-load-scenario.yaml
@@ -1,5 +1,5 @@
 # network-load-scenario.yaml 은 #118 LoadScenario manifest 예제 4 kind 중 network 부하 의 base 다.
-# iperf3 multi-stream 으로 victim Pod 에 sustained 트래픽 을 발생시켜 NetworkDropSpike 또는
+# iperf3 multi-stream 으로 victim Pod 에 sustained 트래픽 을 발생시켜 NetworkDropSpikeDetected 또는
 # correlation-stress 의 cross-pod 간섭 시나리오 를 자극 한다.
 #
 # spec 필드 의미:

--- a/deploy/injector/examples/network-load-scenario.yaml
+++ b/deploy/injector/examples/network-load-scenario.yaml
@@ -1,0 +1,22 @@
+# network-load-scenario.yaml 은 #118 LoadScenario manifest 예제 4 kind 중 network 부하 의 base 다.
+# iperf3 multi-stream 으로 victim Pod 에 sustained 트래픽 을 발생시켜 NetworkDropSpike 또는
+# correlation-stress 의 cross-pod 간섭 시나리오 를 자극 한다.
+#
+# spec 필드 의미:
+#   intensity: network 의 경우 bandwidth (iperf3 -b 형식). 예: "500M" 은 500 Mbps. 안전 상한 1000M.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-network-load
+  namespace: ebpf-project
+spec:
+  schedule: "@every 15m"
+  kind: network
+  duration: 2m
+  # 500M = 500 Mbps. dev cluster 의 typical NIC capacity (1 Gbps) 의 50% 점유 의도.
+  intensity: 500M
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  concurrencyPolicy: Forbid
+  maxFailures: 3

--- a/deploy/injector/examples/spike-assertion-scenario.yaml
+++ b/deploy/injector/examples/spike-assertion-scenario.yaml
@@ -1,0 +1,27 @@
+# spike-assertion-scenario.yaml 은 #118 LoadScenario manifest 예제 의 spikeAlertAssertion 활성
+# 시나리오 base 다. spikeAlertAssertion=true 로 두면 controller 가 부하 종료 시점 부터 5 분 polling
+# window 동안 Prometheus 의 ALERTS 시리즈 를 query 해 z-score spike alert (CPUThrottleSpike /
+# MemoryPressureSpike / NetworkDropSpike / GPUUtilizationSpike) 발화 hit 을 status.lastObservedSpikeAlerts
+# 에 기록 한다. 자동 회귀 검증 시나리오 의 base 로 활용 한다.
+#
+# 본 시나리오 는 cpu 부하 + 부하 종료 후 5 분 polling window 안 의 CPUThrottleSpike 발화 정합 을
+# 자동 검증 한다. 운영자는 본 base 를 다른 kind 로 변경 해 (kind: memory + MemoryPressureSpike,
+# kind: network + NetworkDropSpike, kind: gpu + GPUUtilizationSpike) 4 도메인 모두 cover 가능 하다.
+apiVersion: injector.netobs.io/v1alpha1
+kind: LoadScenario
+metadata:
+  name: example-spike-assertion
+  namespace: ebpf-project
+spec:
+  schedule: "@every 30m"
+  kind: cpu
+  duration: 3m
+  # 1500m = 1.5 core. CPUThrottleSpike z-score 임계 (#89 의 anomaly-spike) 초과 자극.
+  intensity: 1500m
+  targetRef:
+    namespace: correlation-stress
+    name: victim
+  concurrencyPolicy: Forbid
+  # spikeAlertAssertion=true 로 두면 부하 종료 후 status 에 alert 발화 hit 자동 기록.
+  spikeAlertAssertion: true
+  maxFailures: 3

--- a/deploy/injector/examples/spike-assertion-scenario.yaml
+++ b/deploy/injector/examples/spike-assertion-scenario.yaml
@@ -1,12 +1,15 @@
 # spike-assertion-scenario.yaml 은 #118 LoadScenario manifest 예제 의 spikeAlertAssertion 활성
 # 시나리오 base 다. spikeAlertAssertion=true 로 두면 controller 가 부하 종료 시점 부터 5 분 polling
-# window 동안 Prometheus 의 ALERTS 시리즈 를 query 해 z-score spike alert (CPUThrottleSpike /
-# MemoryPressureSpike / NetworkDropSpike / GPUUtilizationSpike) 발화 hit 을 status.lastObservedSpikeAlerts
-# 에 기록 한다. 자동 회귀 검증 시나리오 의 base 로 활용 한다.
+# window 동안 Prometheus 의 ALERTS 시리즈 를 query 해 z-score spike alert (CPUThrottleSpikeDetected /
+# MemoryPressureSpikeDetected / NetworkDropSpikeDetected / GPUUtilSpikeDetected) 발화 hit 을
+# status.lastObservedSpikeAlerts 에 기록 한다. 자동 회귀 검증 시나리오 의 base 로 활용 한다.
+# alert 이름 은 deploy/gpuobs/base/prometheus-rule.yaml 의 정의 와 internal/injector/controller/
+# spike_asserter.go 의 SpikeAlertNames enum 과 정합 한다.
 #
-# 본 시나리오 는 cpu 부하 + 부하 종료 후 5 분 polling window 안 의 CPUThrottleSpike 발화 정합 을
-# 자동 검증 한다. 운영자는 본 base 를 다른 kind 로 변경 해 (kind: memory + MemoryPressureSpike,
-# kind: network + NetworkDropSpike, kind: gpu + GPUUtilizationSpike) 4 도메인 모두 cover 가능 하다.
+# 본 시나리오 는 cpu 부하 + 부하 종료 후 5 분 polling window 안 의 CPUThrottleSpikeDetected 발화
+# 정합 을 자동 검증 한다. 운영자는 본 base 를 다른 kind 로 변경 해 (kind: memory + MemoryPressureSpikeDetected,
+# kind: network + NetworkDropSpikeDetected, kind: gpu + GPUUtilSpikeDetected) 4 도메인 모두 cover
+# 가능 하다.
 apiVersion: injector.netobs.io/v1alpha1
 kind: LoadScenario
 metadata:
@@ -16,7 +19,7 @@ spec:
   schedule: "@every 30m"
   kind: cpu
   duration: 3m
-  # 1500m = 1.5 core. CPUThrottleSpike z-score 임계 (#89 의 anomaly-spike) 초과 자극.
+  # 1500m = 1.5 core. CPUThrottleSpikeDetected z-score 임계 (#89 의 anomaly-spike) 초과 자극.
   intensity: 1500m
   targetRef:
     namespace: correlation-stress

--- a/docs/injector/auto-scenarios.md
+++ b/docs/injector/auto-scenarios.md
@@ -95,6 +95,32 @@ spec:
   maxFailures: 3
 ```
 
+## examples 디렉토리 활용 (#118)
+
+위 inline 샘플은 빠른 참조용이고 `kubectl apply` 로 직접 사용 가능한 base manifest 8종은 `deploy/injector/examples/` 에 별도 정리되어 있다 (#118). 운영자가 신규 LoadScenario CR을 작성할 때 본 디렉토리의 yaml을 복사 후 `targetRef`와 `schedule`만 운영 환경에 맞춰 정정하면 즉시 적용 가능하다.
+
+### 추천 base 매트릭스
+
+| 시나리오 | 추천 base yaml |
+|---|---|
+| CPU 부하 (cgroup throttling 자극) | `cpu-stress-scenario.yaml` |
+| memory 압박 (OOM 인접 신호) | `memory-pressure-scenario.yaml` |
+| GPU 부하 (RTX 3090 단일 GPU) | `gpu-load-scenario.yaml` |
+| network 트래픽 (iperf3 multi-stream) | `network-load-scenario.yaml` |
+| 동일 target 단일 lock 시나리오 | `concurrency-allow-scenario.yaml` |
+| 기존 run 보유 시 skip 의도 | `concurrency-forbid-scenario.yaml` |
+| 기존 lease 해제 후 신규 trigger | `concurrency-replace-scenario.yaml` |
+| 부하 종료 후 z-score spike alert 자동 검증 | `spike-assertion-scenario.yaml` |
+
+### 운영자 워크플로우
+
+- `deploy/injector/examples/` 의 추천 base yaml을 운영 환경의 임시 디렉토리로 복사
+- `targetRef.namespace`와 `targetRef.name`을 실제 부하 인가 대상 Pod로 정정
+- `schedule` 의 cron 표현식을 운영 의도에 맞춰 조정 (`@every 1m` 같은 짧은 schedule은 dev cluster 검증 한정)
+- `intensity` 의 안전 상한 (cpu 4000m, memory 2Gi, network 1000M, gpu 1) 을 넘지 않게 정정
+- `kubectl apply -f <정정한-yaml>` 적용 후 `kubectl get loadscenario -n <namespace>` 로 controller reconcile 진입 확인
+- `status.lastScheduleTime`과 `status.lastSuccessfulRunTime` 갱신으로 정상 동작 확인
+
 ## Troubleshooting
 
 ### reconciler stalled (`LoadScenarioReconcilerStalled` critical alert)

--- a/test/perf/loadscenario/verify.sh
+++ b/test/perf/loadscenario/verify.sh
@@ -47,6 +47,11 @@ echo "[setup] 3차 가드 LoadScenario CR 적용 (@every 1m 짧은 schedule)"
 # window 동안 prometheus 의 ALERTS 시리즈 를 query 해 status 갱신 이 polling timeout 보다 더
 # 늦어진다. 본 가드 는 controller 의 schedule 따른 reconcile 정상 동작 만 검증 하고 spike alert
 # 자동 검증 은 별도 시나리오 로 follow-up.
+# 본 inline yaml 은 #118 의 deploy/injector/examples/cpu-stress-scenario.yaml 을 base 로 하되 dev
+# cluster 가드 시간 단축 목적 으로 schedule (@every 10m → @every 1m) 과 duration (2m → 30s) 와
+# intensity (800m → 500m) 만 정정 한 변형 이다. 운영자가 examples/ base 를 그대로 활용 하려면 본
+# verify.sh 가 아닌 manual `kubectl apply -f deploy/injector/examples/cpu-stress-scenario.yaml` 흐름
+# 으로 적용 한다 (본 verify.sh 의 5 차 가드 절에서 examples/ validation 별도 cover).
 cat <<EOF | kubectl apply -f -
 apiVersion: injector.netobs.io/v1alpha1
 kind: LoadScenario
@@ -105,5 +110,28 @@ fi
 echo "[skip] 5차 가드 spike alert 자동 검증 은 본 가드 의 spec.spikeAlertAssertion=false 채택 으로 skip"
 echo "       spike alert 자동 검증 단독 시나리오 는 follow-up issue 로 분리"
 
-echo "[pass] LoadScenario controller 회귀 가드 1-4 단계 통과"
+# 6차 가드 (#118): deploy/injector/examples/ 의 8 base manifest 가 CRD validation 통과 하는지 확인.
+# 본 가드 는 examples/ 의 운영자 학습 자료 가 controller 의 CRD spec 정합 을 유지 하는지 회귀 차단.
+echo "[check] 6차 가드 examples/ 의 8 base manifest CRD validation (#118)"
+EXAMPLES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/deploy/injector/examples"
+if [[ -d "${EXAMPLES_DIR}" ]]; then
+  all_pass=1
+  for f in "${EXAMPLES_DIR}"/*.yaml; do
+    name=$(basename "${f}")
+    if ! kubectl apply --dry-run=server -f "${f}" >/dev/null 2>&1; then
+      echo "  [fail] ${name} server-side validation 실패"
+      all_pass=0
+    fi
+  done
+  if (( all_pass == 1 )); then
+    echo "[pass] examples/ 8 manifest 모두 CRD validation 통과"
+  else
+    echo "[fail] examples/ 의 manifest 중 일부 가 CRD validation 실패. examples 정합 회귀 의심"
+    exit 1
+  fi
+else
+  echo "[warn] deploy/injector/examples/ 디렉토리 부재. #118 의 examples 신설 누락 여부 점검"
+fi
+
+echo "[pass] LoadScenario controller 회귀 가드 1-4 단계와 6차 (examples validation) 통과"
 exit 0

--- a/test/perf/loadscenario/verify.sh
+++ b/test/perf/loadscenario/verify.sh
@@ -112,25 +112,40 @@ echo "       spike alert 자동 검증 단독 시나리오 는 follow-up issue �
 
 # 6차 가드 (#118): deploy/injector/examples/ 의 8 base manifest 가 CRD validation 통과 하는지 확인.
 # 본 가드 는 examples/ 의 운영자 학습 자료 가 controller 의 CRD spec 정합 을 유지 하는지 회귀 차단.
-echo "[check] 6차 가드 examples/ 의 8 base manifest CRD validation (#118)"
+# 디렉토리 부재 / 0 yaml 매칭 / validation 실패 모두 fail-on-miss 로 처리 해 examples 회귀 차단 강화.
+echo "[check] 6차 가드 examples/ 의 base manifest CRD validation (#118)"
 EXAMPLES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/deploy/injector/examples"
-if [[ -d "${EXAMPLES_DIR}" ]]; then
-  all_pass=1
-  for f in "${EXAMPLES_DIR}"/*.yaml; do
-    name=$(basename "${f}")
-    if ! kubectl apply --dry-run=server -f "${f}" >/dev/null 2>&1; then
-      echo "  [fail] ${name} server-side validation 실패"
-      all_pass=0
-    fi
-  done
-  if (( all_pass == 1 )); then
-    echo "[pass] examples/ 8 manifest 모두 CRD validation 통과"
-  else
-    echo "[fail] examples/ 의 manifest 중 일부 가 CRD validation 실패. examples 정합 회귀 의심"
-    exit 1
+if [[ ! -d "${EXAMPLES_DIR}" ]]; then
+  echo "[fail] deploy/injector/examples/ 디렉토리 부재. #118 의 examples 신설 누락"
+  exit 1
+fi
+
+# nullglob 으로 yaml 미매칭 시 빈 슬라이스 보장. 매칭 안 되면 0 count 로 fail.
+shopt -s nullglob
+example_files=("${EXAMPLES_DIR}"/*.yaml)
+shopt -u nullglob
+
+if (( ${#example_files[@]} == 0 )); then
+  echo "[fail] examples/ 디렉토리에 검증할 yaml 파일 부재"
+  exit 1
+fi
+
+all_pass=1
+for f in "${example_files[@]}"; do
+  name=$(basename "${f}")
+  # 에러 메시지를 캡처 해 debugging 가능 하게 한다. >/dev/null 만 두면 어느 필드 validation 실패 인지
+  # 운영자가 즉시 추적 불가.
+  if ! err_msg=$(kubectl apply --dry-run=server -f "${f}" 2>&1); then
+    echo "  [fail] ${name} server-side validation 실패"
+    echo "         에러 상세: ${err_msg}"
+    all_pass=0
   fi
+done
+if (( all_pass == 1 )); then
+  echo "[pass] examples/ ${#example_files[@]}개 manifest 모두 CRD validation 통과"
 else
-  echo "[warn] deploy/injector/examples/ 디렉토리 부재. #118 의 examples 신설 누락 여부 점검"
+  echo "[fail] examples/ 의 manifest 중 일부 가 CRD validation 실패. examples 정합 회귀 의심"
+  exit 1
 fi
 
 echo "[pass] LoadScenario controller 회귀 가드 1-4 단계와 6차 (examples validation) 통과"


### PR DESCRIPTION
## 요약

이슈 #118의 LoadScenario manifest 예제 신설을 3 commit으로 마무리한다. LoadScenario controller와 CRD spec과 self-observability metric과 운영자 가이드와 e2e verify.sh는 모두 #102에서 이미 완성되어 있고 dev cluster의 controller Deployment도 5일 이상 정상 Running 상태다. 본 PR은 운영자가 신규 LoadScenario CR을 작성할 때 참조 가능한 base manifest 예제 부재 갭만 cover하며 controller reconcile 로직 자체 변경은 zero다. 본 PR은 매니페스트와 docs와 verify.sh 보강만 변경하고 코드 변경 zero라 VERSION bump와 image push는 생략한다.

## 8 manifest 예제 신설

`deploy/injector/examples/` 디렉토리에 base manifest 8종 신설.

### kind별 4종

- `cpu-stress-scenario.yaml`: `kind=cpu`, `intensity=800m` (0.8 core 점유), `schedule="@every 10m"`, `targetRef=correlation-stress/victim`
- `memory-pressure-scenario.yaml`: `kind=memory`, `intensity=1Gi` (victim Pod memory limit 2Gi의 50% 점유), `schedule="@every 30m"`
- `gpu-load-scenario.yaml`: `kind=gpu`, `intensity="1"` (dev cluster RTX 3090 단일 GPU 정합), `schedule="@every 1h"`, `targetRef=ebpf-project/pytorch-conv2d-bench`
- `network-load-scenario.yaml`: `kind=network`, `intensity=500M` (1 Gbps NIC의 50% 점유), `schedule="@every 15m"`

### concurrencyPolicy별 3종

- `concurrency-allow-scenario.yaml`: Allow 정책, 동일 target에 대한 lease 충돌 시 conflict error 의도 명시
- `concurrency-forbid-scenario.yaml`: Forbid 정책, 기존 run 보유 시 skip 동작 (consecutiveFailures 미증가)
- `concurrency-replace-scenario.yaml`: Replace 정책, 기존 lease 강제 해제 후 신규 trigger

### spikeAlertAssertion 활성 1종

- `spike-assertion-scenario.yaml`: `spikeAlertAssertion=true`, `intensity=1500m`으로 CPUThrottleSpike z-score 임계 자극. 부하 종료 후 5분 polling window 안의 z-score spike alert 발화 hit을 `status.lastObservedSpikeAlerts`에 자동 기록

각 yaml의 상단에 spec 필드의 운영 의미 (`schedule` cron 표현식, `duration`과 `intensity`의 안전 범위, `targetRef.namespace`와 `name` 매칭 규칙) 와 `internal/injector/safety/safety.go`의 IntensityLimits 안전 상한 (cpu 4000m, memory 2Gi, network 1000M, gpu 1) 근거를 주석으로 명시했다.

## 코드 변경 단위

### Commit 1 manifest 예제 신설

- `feat(injector)` `deploy/injector/examples/` 디렉토리 신설. 8 yaml의 server-side validation 통과 확인과 `cpu-stress-scenario.yaml`의 실제 apply / delete cycle 정합 확인

### Commit 2 docs 갱신

- `docs(injector)` `docs/injector/auto-scenarios.md`의 "샘플 LoadScenario CR" 절(line 75) 직후에 "examples 디렉토리 활용" 절 신설. 추천 base 매트릭스 8행 (kind 4종과 concurrencyPolicy 3종과 spikeAlertAssertion 활성 1종)과 운영자 워크플로우 5단계 (base 복사와 targetRef 정정과 schedule 조정과 intensity 안전 상한 검증과 apply 후 reconcile 진입 확인) 추가

### Commit 3 verify.sh 보강

- `test(perf)` `test/perf/loadscenario/verify.sh`의 3차 가드 inline yaml 주석에 `cpu-stress-scenario.yaml`과의 정합 의도 (schedule과 duration과 intensity 단축) 명시. 6차 가드 신설로 `deploy/injector/examples/`의 8 base manifest가 CRD server-side validation 정합을 회귀 차단

## 검증

### 정적 검증

- `kubectl apply --dry-run=server`로 8 yaml 모두 CRD validation 통과 확인
- `bash -n test/perf/loadscenario/verify.sh` syntax 통과
- 6차 가드 격리 실행으로 8 manifest validation 정합 확인

### dev cluster 통합 검증 (1-6차 가드 전체 실행)

- 1차 CRD 등록 확인 pass (`loadscenarios.injector.netobs.io` 등록)
- 2차 controller Deployment Ready pass (workload-injector-controller rollout 완료)
- 3차 LoadScenario CR 적용 pass (`verify-cpu-smoke` 생성)
- 4차 status.lastScheduleTime 갱신 pass (`2026-06-08T02:16:59Z`, controller가 schedule trigger 정상 평가)
- 4차 status.lastSuccessfulRunTime 갱신 pass (`2026-06-08T02:17:29Z`, duration 30s 경과 후 success 기록 정합)
- 5차 spike alert skip (의도, `spikeAlertAssertion=false`)
- 6차 examples validation pass (8 manifest 모두 CRD validation 통과)
- trap cleanup 정상 동작 (LoadScenario CR 자동 정리)

### 회귀 점검

- 본 PR의 6차 가드 추가가 기존 1-4차 흐름에 영향 zero임을 실측으로 확인
- controller reconcile 로직 자체 변경 zero라 #102의 동작 회귀도 zero

## 호환성과 확장성

- 본 PR은 코드 변경 zero (매니페스트와 docs와 verify.sh만)라 기존 동작 회귀 zero
- 기존 inline yaml 패턴 (verify.sh의 heredoc과 docs의 line 75 샘플) 은 그대로 유지하면서 `examples/` 추가로 도입. 운영자가 두 패턴 중 자유 선택 가능
- 향후 LoadScenario kind 추가 시 `examples/`에 신규 yaml 1종 추가만으로 cover 가능
- concurrencyPolicy 또는 spikeAlertAssertion 같은 신규 optional 필드 도입 시 `examples/`의 대응 예제 추가만으로 운영자 학습 자료 자연 확장
- 6차 가드가 examples/의 CRD 정합 회귀를 영구 차단하므로 향후 spec 필드 추가나 삭제 시 examples 갱신 누락을 자동 감지

## 비목표

- controller 자체 reconcile 로직 변경은 본 이슈 외 (#102에서 완성)
- 신규 metric 또는 alert 도입은 본 이슈 외
- LoadScenario CRD spec 신규 필드 추가도 본 이슈 외 (현재 spec이 이미 cover)
- prod cluster의 자동 부하 인가는 본 이슈 비목표 (#102 비목표 그대로 유지)
- LoadScenario의 dependency graph (다른 LoadScenario 완료 후 trigger)도 본 이슈 외
- VERSION bump와 image push도 본 PR 외 (코드 변경 zero)
- spike alert 자동 검증 단독 시나리오의 verify.sh 통합은 본 이슈 외 (`spike-assertion-scenario.yaml` 예제는 신설했으나 verify.sh의 5차 가드는 skip 유지)

Closes #118
