### PR TITLE
feat(dashboards): Pod별 네트워크 대역폭 Mbps 단위 가시화 panel 신설

### DIFF
--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -984,7 +984,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "collapsed": false
     },
@@ -1073,7 +1073,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "collapsed": false
     },
@@ -1187,7 +1187,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 85
       },
       "collapsed": false
     },
@@ -1201,7 +1201,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 78
+        "y": 86
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1280,7 +1280,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 78
+        "y": 86
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1343,7 +1343,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 78
+        "y": 86
       },
       "timeFrom": "now-30d",
       "timezone": "Asia/Seoul",
@@ -1438,7 +1438,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 86
+        "y": 94
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1517,7 +1517,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 86
+        "y": 94
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1580,7 +1580,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 86
+        "y": 94
       },
       "timeFrom": "now-30d",
       "timezone": "Asia/Seoul",
@@ -1675,7 +1675,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 94
+        "y": 102
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1754,7 +1754,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 94
+        "y": 102
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1817,7 +1817,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 94
+        "y": 102
       },
       "timeFrom": "now-30d",
       "timezone": "Asia/Seoul",
@@ -1912,7 +1912,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 102
+        "y": 110
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -1991,7 +1991,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 102
+        "y": 110
       },
       "timeFrom": "now-4w",
       "timezone": "Asia/Seoul",
@@ -2054,7 +2054,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 102
+        "y": 110
       },
       "timeFrom": "now-30d",
       "timezone": "Asia/Seoul",
@@ -2147,7 +2147,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 119
       },
       "collapsed": false
     },
@@ -2161,7 +2161,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 120
       },
       "timeFrom": "now-1h",
       "timezone": "browser",
@@ -2256,7 +2256,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 120
       },
       "timeFrom": "now-1h",
       "timezone": "browser",
@@ -2351,7 +2351,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 120
+        "y": 128
       },
       "timeFrom": "now-1h",
       "timezone": "browser",
@@ -2446,7 +2446,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 120
+        "y": 128
       },
       "timeFrom": "now-1h",
       "timezone": "browser",
@@ -2530,6 +2530,95 @@
           "targetBlank": true
         }
       ]
+    },
+    {
+      "id": 401,
+      "type": "timeseries",
+      "title": "Pod 별 RX/TX 대역폭 (Mbps, $src_pod)",
+      "description": "Pod 단위 RX 와 TX 대역폭 의 Mbps 단위 시계열. raw counter netobs_pod_bytes_total 의 layer l4 rate 를 PromQL 단에서 직접 계산해 Mbps 환산 한다. direction 라벨 (egress 와 ingress) 별 시계열 자동 분리 로 RX 와 TX 를 한 panel 에서 비교 가능 하다. Grafana 의 unit Mbits 자동 SI prefix 변환 으로 Kbps 와 Gbps 표기 도 함께 cover 한다.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by(direction) (rate(netobs_pod_bytes_total{layer=\"l4\", node=\"$node\", src_pod=~\"$src_pod\"}[5m])) * 8 / 1000000",
+          "legendFormat": "{{direction}}",
+          "datasource": "${datasource}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Mbits",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "egress"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "egress (TX)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ingress"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "ingress (RX)"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/observability/dashboard-workflow.md
+++ b/docs/observability/dashboard-workflow.md
@@ -30,11 +30,28 @@ cluster 의 이상 신호를 4 단계 (`cluster → node → pod → root cause`
 
 ### 단계 3 — pod 좁힘
 
-`Pod` variable dropdown 에서 단계 2 의 의심 Pod 선택 후 `Pod drill-down` row 의 3 패널을 본다.
+`Pod` variable dropdown 에서 단계 2 의 의심 Pod 선택 후 `Pod drill-down` row 의 4 패널을 본다.
 
 - `Stage latency p99`: 본 Pod 의 stage 별 latency p99 시계열
 - `GPU memory used (Pod)`: GPU 사용 시 메모리 점유량. 미사용 Pod 는 N/A
 - `Noisy neighbor Top-N (victim=$pod)`: `correlation_noisy_neighbor_score` 의 dimension 별 suspect 순위. score 0.85 이상 빨강 / 0.7 주황 / 0.5 노랑 임계 색상으로 즉시 식별
+- `Pod 별 RX/TX 대역폭 (Mbps, $src_pod)` (#130): raw counter `netobs_pod_bytes_total` 의 layer l4 rate를 PromQL 단에서 Mbps 환산한 dual-direction 시계열. egress (TX, blue) 와 ingress (RX, green) 별 분리 표시
+
+#### Pod 별 RX/TX 대역폭 panel 의 활용
+
+본 panel은 Pod 단위 네트워크 대역폭을 Mbps 단위로 즉시 가시화해 운영자가 다음 시나리오에서 활용 가능하다.
+
+- **대역폭 spike 식별**: TX 의 sustained burst가 NIC capacity (`netobs_node_nic_capacity_bytes_per_sec`) 의 50% 이상이면 cross-pod 간섭 의심. `Noisy neighbor Top-N` 표의 network dimension 신호와 cross-reference
+- **RX/TX 비대칭 패턴 인식**: ingress 가 egress 대비 과도하게 높으면 본 Pod가 receive 측 (예: API 수신 서버) 이고 그 반대면 send 측 (예: 미디어 송신). 워크로드 성격에 따른 자연 패턴 비교
+- **drop spike와의 cross-reference**: 같은 시점의 `Node drop / retrans rate (drop_category 별)` panel과 비교. 대역폭 burst가 drop spike를 동반하면 NIC saturation 또는 queue overflow 의심
+
+본 panel 의 query 는 raw counter `netobs_pod_bytes_total` 의 rate를 PromQL 단에서 직접 계산해 신규 recording rule 도입 없이 direction 라벨 분리를 활용한다. unit `Mbits` 설정으로 Grafana 가 Kbps와 Gbps 표기를 자동 SI prefix 변환한다.
+
+본 panel의 비목표는 다음과 같다.
+
+- per-flow 5-tuple 분리는 본 panel 외 (`drop-flow` dashboard와 `netobs_flow_bytes_total` 메트릭 참조)
+- nic layer 의 raw counter 표시는 본 panel 외 (`layer="l4"` 필터 고정으로 cardinality 폐쇄)
+- alert 발화 threshold 도입은 본 panel 외 (별도 follow-up)
 
 ### 단계 4 — root cause 분석
 


### PR DESCRIPTION
## 요약

이슈 #130의 Pod별 네트워크 RX/TX 대역폭 Mbps 단위 가시화 panel 신설을 2 commit으로 마무리한다. `netobs_pod_bytes_total` raw counter와 `pod:network_throughput_bps:5m` recording rule이 PR #47에서 이미 완성되어 있는 인프라 위에 가시화 panel만 추가하고 신규 recording rule 도입은 zero다. `overview.json`의 Pod drill-down row 안에 직접 PromQL 식 (`rate(netobs_pod_bytes_total{layer="l4"}[5m]) * 8 / 1e6`)으로 Mbps 환산해 direction 라벨 (egress와 ingress) 별 시계열 자동 분리 표시한다.

## 신규 panel 설계

`deploy/dashboards/overview.json`의 Pod drill-down row 안에 신규 timeseries panel 1종을 추가한다.

- panel id 401의 gridPos는 x=0과 y=59와 w=24와 h=8
- query expr `sum by(direction) (rate(netobs_pod_bytes_total{layer="l4", node="$node", src_pod=~"$src_pod"}[5m])) * 8 / 1000000`
- legendFormat `{{direction}}`으로 egress와 ingress 자동 분리
- fieldConfig unit `Mbits`로 Grafana의 자동 SI prefix 변환 활성 (Kbps와 Gbps 표기 자동 cover)
- color override egress=blue (TX) 와 ingress=green (RX) 로 시각 구분
- displayName override "egress (TX)" 와 "ingress (RX)" 로 가독성 보강

후속 4 row의 y 좌표는 +8 shift해 신규 panel의 h=8만큼 자연 정렬한다. panel id 14가 기존 "Firing alerts by severity"와 중복되어 신규 panel은 id 401로 부여한다.

## 코드 변경 단위

### Commit 1 panel 신설

- `feat(dashboards)` `deploy/dashboards/overview.json`의 Pod drill-down row 안에 신규 timeseries panel 추가
- 후속 row의 y 좌표 +8 shift로 layout 자연 정렬
- panel id 14 중복 회피 위해 신규 panel id 401 부여

### Commit 2 docs 갱신

- `docs(observability)` `docs/observability/dashboard-workflow.md`의 단계 3 (pod 좁힘) 패널 셋에 신규 panel 추가
- 부속 절 (`#### "Pod 별 RX/TX 대역폭 panel 의 활용"`) 신설로 운영자 활용 시나리오 3종과 raw counter rate 직접 계산 의도와 unit Mbits 자동 변환 동작 정리

## 검증

### 정적 검증

- `jq empty deploy/dashboards/overview.json` JSON 유효성 통과
- panel id 중복 검사 (id 14에서 401 정정 후) 통과
- markdown heading depth 정합 검증 통과 (단계 3 부속으로 `####` 깊이 적용)

### dev cluster 통합 검증

- `make deploy-dashboards` ConfigMap 갱신 정상 종료
- Prometheus instant query `sum by(direction) (rate(netobs_pod_bytes_total{layer="l4"}[5m])) * 8 / 1000000`의 status `success`와 series 2개 (egress와 ingress) emit 확인
- dev cluster의 자연 트래픽 환경에서 24 series 정상 emit 확인 (`kube-system`과 `default` namespace의 Pod별 RX/TX 분리)
- Grafana overview dashboard의 Pod drill-down row에서 신규 panel의 RX/TX 시계열 분리 표시 확인

### 전체 시스템 회귀 점검

- 5 agent Pod (`netobs-agent`와 `gpuobs-agent`와 `correlation-exporter`와 `rca-summarizer`와 `workload-injector-controller`) 모두 Running 상태와 restart count 0 확인
- 각 agent의 `/metrics` endpoint scrape 정상 동작 확인 (metric 라인 수 정합)
- 기존 핵심 메트릭의 series count 회귀 zero 확인 (`gpuobs_device_utilization_percent`와 `netobs_pod_bytes_total`와 `correlation_noisy_neighbor_score` 3종)
- 기존 Pod drill-down 내부 panel 3종 (Stage latency p99와 GPU memory used와 Noisy neighbor Top-N) 의 layout 변경 zero
- 후속 4 row (Cross-node interference와 Alert summary와 Capacity trends와 Resource anomaly) 의 panel 회귀 zero (y 좌표 +8 일관 shift)
- 기존 `netobs_pod_bytes_total` counter와 `pod:network_throughput_bps:5m` recording rule 변경 zero
- 기존 dashboard의 다른 row와 templating 변수 변경 zero
- dev cluster의 14 firing alert는 본 PR과 무관한 기존 운영 상태 (`TargetDown` 외)

## 호환성과 확장성

- 신규 recording rule 도입 없이 PromQL 단에서 raw counter rate 직접 계산이라 cardinality 영향 zero
- `node`와 `src_pod` 변수의 single selection 강제로 panel 시계열 수가 direction 2종만으로 cap
- `layer="l4"` 필터로 cardinality 폐쇄 유지 (nic layer 시리즈 제외)
- 본 panel의 query 식이 향후 ingress/egress 분리 recording rule 도입 시 자연 교체 가능

## 비목표

- 신규 BPF 측정 도입은 본 PR 외 (기존 counter 재사용)
- recording rule 신설은 본 PR 외 (raw counter rate 직접 계산)
- alert rule 신설은 본 PR 외
- per-flow 5-tuple 분리는 본 PR 외 (`drop-flow` dashboard와 `netobs_flow_bytes_total` 메트릭 참조)
- nic layer의 raw counter 표시는 본 PR 외 (`layer="l4"` 필터 고정)

본 PR은 코드 변경 zero (dashboard json과 docs markdown만)라 VERSION bump와 image push 불요다.

Closes #130
