### PR TITLE
feat(dashboards): overview 대시보드 시나리오별 row 신설

### DIFF
--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -2619,6 +2619,121 @@
           ]
         }
       }
+    },
+    {
+      "id": 800,
+      "type": "row",
+      "title": "시나리오. GPU idle 진단 진입점",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 136
+      },
+      "panels": [
+        {
+          "id": 801,
+          "type": "timeseries",
+          "title": "GPU idle cause weight (5 cause stacked)",
+          "description": "pod:gpu_idle_cause_weight:5m 의 5 cause (pcie_saturation과 network_pressure과 cpu_throttle과 memory_pressure과 host_compute_stall) weight를 stacked로 표시한다. GPU 유휴 시간대에 어느 cause가 dominant인지 한눈에 식별한다. dev cluster의 RTX 3090 환경에서 nccl_collective_stall과 dcgm_pcie_replay 슬롯은 0 weight로 emit된다.",
+          "datasource": "${datasource}",
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 137
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "pod:gpu_idle_cause_weight:5m",
+              "legendFormat": "{{cause}}",
+              "datasource": "${datasource}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "min": 0,
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 40,
+                "showPoints": "never",
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            }
+          },
+          "links": [
+            {
+              "title": "Drill into correlation overview",
+              "url": "/d/correlation-overview?${__url_time_range}",
+              "targetBlank": true
+            }
+          ]
+        },
+        {
+          "id": 802,
+          "type": "stat",
+          "title": "Dominant cause indicator",
+          "description": "cluster:gpu_idle_dominant_cause:5m 의 dominant cause 1종을 노출한다. 5 cause weight 중 최대값 cause가 표시되며 weight 시리즈가 idle 게이팅으로 emit되지 않는 시간대는 N/A다.",
+          "datasource": "${datasource}",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 137
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "count by(cause) (cluster:gpu_idle_dominant_cause:5m)",
+              "legendFormat": "{{cause}}",
+              "datasource": "${datasource}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "N/A (GPU 유휴 아님)",
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "1": {
+                      "text": " "
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "textMode": "name"
+          }
+        }
+      ]
     }
   ]
 }

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -2636,7 +2636,7 @@
           "id": 801,
           "type": "timeseries",
           "title": "GPU idle cause weight (5 cause stacked)",
-          "description": "pod:gpu_idle_cause_weight:5m 의 5 cause (pcie_saturation과 network_pressure과 cpu_throttle과 memory_pressure과 host_compute_stall) weight를 stacked로 표시한다. GPU 유휴 시간대에 어느 cause가 dominant인지 한눈에 식별한다. dev cluster의 RTX 3090 환경에서 nccl_collective_stall과 dcgm_pcie_replay 슬롯은 0 weight로 emit된다.",
+          "description": "avg by(cause) (pod:gpu_idle_cause_weight:5m) 의 5 cause (pcie_saturation과 network_pressure과 cpu_throttle과 memory_pressure과 host_compute_stall) weight를 cluster 평균으로 집계해 stacked로 표시한다. victim 단위 raw 메트릭을 cause 차원으로 avg 집계해 stacked 합이 victim 수에 비례해 부풀려지던 문제를 해소한다. 개별 cause weight는 0-1 범위이며 상대 크기로 어느 cause가 dominant인지 한눈에 식별한다. dev cluster의 RTX 3090 환경에서 nccl_collective_stall과 dcgm_pcie_replay 슬롯은 0 weight로 emit된다.",
           "datasource": "${datasource}",
           "gridPos": {
             "h": 8,
@@ -2647,7 +2647,7 @@
           "targets": [
             {
               "refId": "A",
-              "expr": "pod:gpu_idle_cause_weight:5m{node=~\"$node\"}",
+              "expr": "avg by(cause) (pod:gpu_idle_cause_weight:5m{node=~\"$node\"})",
               "legendFormat": "{{cause}}",
               "datasource": "${datasource}"
             }
@@ -2751,7 +2751,7 @@
           "id": 811,
           "type": "timeseries",
           "title": "Drop burst rate (5-tuple, 초당 이벤트)",
-          "description": "netobs_drop_burst:rate1m 의 5-tuple 별 drop burst rate (초당 이벤트) 시계열. src_namespace와 src_pod와 drop_reason 라벨을 보존해 어느 connection이 drop을 일으키는지 식별한다. dev cluster의 자연 drop burst 부재 환경에서는 No data로 graceful empty 표시된다.",
+          "description": "netobs_drop_burst:rate1m 의 5-tuple 별 drop burst rate (초당 이벤트) 시계열. src_namespace와 src_pod와 drop_reason 라벨을 보존해 어느 connection이 drop을 일으키는지 식별한다. 본 recording rule은 5-tuple 단위 집계라 node 라벨을 보존하지 않으므로 상단 node 변수와 무관하게 cluster 전체 burst를 topk 20으로 노출한다. node 단위 분포는 아래 Node drop rate panel에서 확인한다. dev cluster의 자연 drop burst 부재 환경에서는 No data로 graceful empty 표시된다.",
           "datasource": "${datasource}",
           "gridPos": {
             "h": 8,

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -2734,6 +2734,125 @@
           }
         }
       ]
+    },
+    {
+      "id": 810,
+      "type": "row",
+      "title": "시나리오. Drop spike 추적 진입점",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 146
+      },
+      "panels": [
+        {
+          "id": 811,
+          "type": "timeseries",
+          "title": "Drop burst rate (5-tuple, 초당 이벤트)",
+          "description": "netobs_drop_burst:rate1m 의 5-tuple 별 drop burst rate (초당 이벤트) 시계열. src_namespace와 src_pod와 drop_reason 라벨을 보존해 어느 connection이 drop을 일으키는지 식별한다. dev cluster의 자연 drop burst 부재 환경에서는 No data로 graceful empty 표시된다.",
+          "datasource": "${datasource}",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 147
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "topk(20, netobs_drop_burst:rate1m)",
+              "legendFormat": "{{src_namespace}}/{{src_pod}} {{drop_reason}} ({{dst_ip}}:{{dst_port}})",
+              "datasource": "${datasource}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "min": 0,
+              "noValue": "No data (drop burst 부재)",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ]
+            }
+          },
+          "links": [
+            {
+              "title": "Drill into netobs overview",
+              "url": "/d/netobs-overview?${__url_time_range}",
+              "targetBlank": true
+            }
+          ]
+        },
+        {
+          "id": 812,
+          "type": "timeseries",
+          "title": "Node drop rate (drop_category 별)",
+          "description": "node 와 drop_category 별 drop event rate (초당) 시계열. NetworkPolicy 위반과 conntrack과 protocol error 등 drop_category 분포로 drop 의 성격을 분류한다. 시나리오 1 의 drop burst 와 cross-reference해 spike 의 카테고리를 특정한다.",
+          "datasource": "${datasource}",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 155
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "sum by(node, drop_category) (rate(netobs_drop_events_labeled_total[5m]))",
+              "legendFormat": "{{node}} {{drop_category}}",
+              "datasource": "${datasource}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "min": 0,
+              "noValue": "No data (drop 부재)",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "calcs": [
+                "max",
+                "lastNotNull"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -2647,7 +2647,7 @@
           "targets": [
             {
               "refId": "A",
-              "expr": "pod:gpu_idle_cause_weight:5m",
+              "expr": "pod:gpu_idle_cause_weight:5m{node=~\"$node\"}",
               "legendFormat": "{{cause}}",
               "datasource": "${datasource}"
             }
@@ -2687,7 +2687,7 @@
           "links": [
             {
               "title": "Drill into correlation overview",
-              "url": "/d/correlation-overview?${__url_time_range}",
+              "url": "/d/correlation-overview?var-victim_node=${node:regex}&var-victim_pod=${src_pod:regex}&${__url_time_range}",
               "targetBlank": true
             }
           ]
@@ -2798,7 +2798,7 @@
           "links": [
             {
               "title": "Drill into netobs overview",
-              "url": "/d/netobs-overview?${__url_time_range}",
+              "url": "/d/netobs-overview?var-node=${node:regex}&var-src_pod=${src_pod:regex}&${__url_time_range}",
               "targetBlank": true
             }
           ]
@@ -2818,7 +2818,7 @@
           "targets": [
             {
               "refId": "A",
-              "expr": "sum by(node, drop_category) (rate(netobs_drop_events_labeled_total[5m]))",
+              "expr": "sum by(node, drop_category) (rate(netobs_drop_events_labeled_total{node=~\"$node\"}[5m]))",
               "legendFormat": "{{node}} {{drop_category}}",
               "datasource": "${datasource}"
             }

--- a/docs/observability/dashboard-workflow.md
+++ b/docs/observability/dashboard-workflow.md
@@ -84,6 +84,16 @@ cluster 의 이상 신호를 4 단계 (`cluster → node → pod → root cause`
 | `BlastRadiusHigh` | warning | `target_pod`, `kind`, `victim_pod`, `victim_namespace` | `$pod` = `victim_pod`, suspect 는 `target_pod` |
 | `InjectorStuck` | critical | `target_namespace`, `target_pod`, `kind` | `$pod` = `target_pod` |
 
+## 시나리오별 진입점 row
+
+dashboard 하단에 운영 시나리오별 collapsed row를 두어 운영자가 4 단계 워크플로 외에 시나리오 단위로도 진단을 시작할 수 있다. collapsed 상태로 시작하므로 row 헤더를 클릭해 펼친 뒤 사용한다.
+
+- **GPU idle 진단 진입점** (id 800): `pod:gpu_idle_cause_weight:5m` 의 5 cause weight stacked bar와 `cluster:gpu_idle_dominant_cause:5m` dominant cause indicator로 구성된다. dominant cause를 식별한 뒤 row의 `correlation-overview` drill-down link로 이동해 noisy neighbor 페어를 확정한다
+- **Drop spike 추적 진입점** (id 810): `netobs_drop_burst:rate1m` 의 5-tuple별 burst rate 시계열과 node와 drop_category별 drop rate 분포로 구성된다. burst를 일으키는 connection을 식별한 뒤 row의 `netobs-overview` drill-down link로 이동해 drop reason과 kernel stack을 확정한다
+- **Capacity 계획 진입점**: 별도 신규 row 없이 기존 `Capacity trends` row (id 600) 와 `Resource anomaly spike` row (id 700) 를 진입점으로 활용한다. 4주 heatmap의 시간대 패턴과 z-score 추세 이탈로 capacity 선행 신호를 본다
+
+세 시나리오의 전체 흐름은 [ONBOARDING.md](../ONBOARDING.md)의 주요 운영 시나리오 절에서 단계별 표로 안내한다.
+
 ## annotation 의 활용
 
 dashboard 의 모든 timeline 패널에 `ALERTS{alertstate="firing"}` 가 annotation 으로 표시된다. 시점이 health score 의 anomaly 와 일치하면 그 alert 가 변동 원인일 가능성이 높다. annotation 클릭 시 tag 라벨 (`severity`, `component`, `alertname`) 이 노출되어 단계 2 의 variable 선택을 즉시 결정 가능하다.


### PR DESCRIPTION
## 요약

이슈 #132의 overview 대시보드 시나리오별 진입점 row 신설을 3 commit으로 마무리한다. 시나리오 3종 중 Capacity 계획은 기존 Capacity trends row (id 600, PR #88) 가 이미 완성되어 있어 GPU idle 진단과 Drop spike 추적 2종만 신규 collapsed row로 추가한다. 신규 recording rule 도입 없이 기존 메트릭을 재사용하고 기존 8 row의 y 좌표 변경 없이 맨 아래 추가해 회귀를 차단한다.

## 시나리오별 진입점 설계

운영자가 4 단계 워크플로 외에 시나리오 단위로도 진단을 시작할 수 있도록 dashboard 하단에 collapsed row 2종을 추가한다. collapsed 상태로 시작해 운영자가 시나리오 선택 시 펼친다.

- GPU idle 진단 진입점 (id 800): `pod:gpu_idle_cause_weight:5m`의 5 cause weight stacked bar와 `cluster:gpu_idle_dominant_cause:5m` dominant cause indicator로 구성. `correlation-overview` drill-down link 부착
- Drop spike 추적 진입점 (id 810): `netobs_drop_burst:rate1m`의 5-tuple별 burst rate 시계열과 node와 drop_category별 drop rate 분포로 구성. `netobs-overview` drill-down link 부착

Capacity 계획은 기존 Capacity trends row (id 600) 와 Resource anomaly spike row (id 700) 를 진입점으로 활용하며 신규 row를 추가하지 않는다.

## 코드 변경 단위

### Commit 1 GPU idle 진단 row

- `feat(dashboards)` `deploy/dashboards/overview.json` 맨 아래에 collapsed row (id 800) 와 nested panel 2종을 추가
- nested panel은 5 cause weight stacked bar와 dominant cause indicator 2종
- `correlation-overview` drill-down link 부착

### Commit 2 Drop spike 추적 row

- `feat(dashboards)` collapsed row (id 810) 와 nested panel 2종을 추가
- nested panel은 5-tuple burst rate 시계열과 node의 drop_category 분포 2종
- `netobs-overview` drill-down link 부착과 dev cluster의 자연 drop burst 부재 환경의 graceful empty (`No data`) 처리

### Commit 3 docs 갱신

- `docs(observability)` `docs/observability/dashboard-workflow.md`에 시나리오별 진입점 row 절을 추가
- GPU idle 진단 row와 Drop spike 추적 row의 위치와 펼침 방법과 drill-down link 흐름을 정리
- Capacity 계획은 기존 row 활용 명시와 `ONBOARDING.md` 참조 link

## 검증

### 정적 검증

- `jq empty deploy/dashboards/overview.json` JSON 유효성 통과
- panel id 중복 검사 (nested 포함 49 panel) 0건
- markdown heading depth 정합과 `ONBOARDING.md` link 정합 검증 통과

### dev cluster 통합 검증

- `make deploy-dashboards` ConfigMap 갱신 정상 종료
- `ebpf-project` namespace의 `overview-dashboard` ConfigMap에 신규 시나리오 2 row 반영 확인 (전체 10 row)
- 신규 row의 모든 panel query Prometheus instant query status success
  - `pod:gpu_idle_cause_weight:5m`는 52 series
  - `cluster:gpu_idle_dominant_cause:5m`는 1 series
  - `netobs_drop_burst:rate1m`는 0 series (drop burst 부재 환경의 graceful empty 정상)
  - `netobs_drop_events_labeled_total` rate는 3 series
- 두 신규 row가 collapsed 상태로 시작 확인

### 회귀 점검

- 기존 8 row의 y 좌표 변경 zero (신규 row는 y=136과 146에 맨 아래 추가)
- 기존 4 health score (`cluster:gpu_health_score:5m`와 `cluster:cpu_health_score:5m`와 `cluster:network_health_score:5m`와 `cluster:memory_health_score:5m`) 정상 emit 확인
- 신규 recording rule 도입 zero (기존 메트릭 재사용)
- 다른 dashboard 변경 zero

## 호환성과 확장성

- 신규 row가 collapsed 상태라 기존 dashboard 진입 시 화면 변화 최소
- 기존 메트릭 재사용으로 cardinality 영향 zero
- 시나리오 row의 query가 향후 신규 cause 슬롯 (`nccl_collective_stall`과 `dcgm_pcie_replay`) 도입 시 자동 반영 (`pod:gpu_idle_cause_weight:5m`의 모든 cause emit)

## 비목표

- 신규 recording rule 신설은 본 PR 외 (기존 rule 재사용)
- alert rule 추가는 본 PR 외
- 다른 dashboard 변경은 본 PR 외
- forecast 기반 예측 panel 추가는 별도 follow-up
- Capacity 계획 전용 신규 row는 본 PR 외 (기존 Capacity trends row 활용)

본 PR은 dashboard json과 docs markdown만 변경이라 VERSION bump와 image push 불요다.

Closes #132
