### PR TITLE
feat(dashboards): stale 라벨 정리와 적응형 이상 하이라이트와 pod 통합 뷰 고도화

### DIFF
--- a/deploy/correlation/base/servicemonitor.yaml
+++ b/deploy/correlation/base/servicemonitor.yaml
@@ -24,3 +24,8 @@ spec:
       # 메트릭 (reconcile_duration, last_success_timestamp) 은 30s scrape 로 충분한 해상도를 얻는다.
       interval: 30s
       scrapeTimeout: 10s
+      # #178 stale 시리즈 근본 정리. correlation-exporter 는 단일 replica Deployment 라 pod/instance 를
+      # drop 해도 인스턴스 collision 이 없고, 재시작 시 바뀌던 pod/instance stale churn 만 제거된다.
+      metricRelabelings:
+        - regex: pod|instance
+          action: labeldrop

--- a/deploy/dashboards/kustomization.yaml
+++ b/deploy/dashboards/kustomization.yaml
@@ -84,6 +84,18 @@ configMapGenerator:
         app.kubernetes.io/name: ebpf-project
         app.kubernetes.io/component: grafana-dashboard
         app.kubernetes.io/part-of: ebpf-project
+  # #178 pod 중심 drill-down. netobs / gpuobs / correlation 에 분산된 pod 패널을 단일 pod 기준으로
+  # 통합해 한 pod 의 latency 와 drop 과 network 와 GPU 를 동시에 본다. cross-domain 통합 뷰라 part-of
+  # 는 ebpf-project 로 둔다.
+  - name: pod-drilldown-dashboard
+    files:
+      - pod-drilldown.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: ebpf-project
+        app.kubernetes.io/component: grafana-dashboard
+        app.kubernetes.io/part-of: ebpf-project
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/deploy/dashboards/pod-drilldown.json
+++ b/deploy/dashboards/pod-drilldown.json
@@ -1,0 +1,298 @@
+{
+  "title": "pod drill-down",
+  "uid": "pod-drilldown",
+  "tags": [
+    "ebpf",
+    "netobs",
+    "gpuobs",
+    "pod-centric"
+  ],
+  "schemaVersion": 38,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource"
+      },
+      {
+        "name": "src_namespace",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count, src_namespace)",
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false,
+        "label": "Namespace"
+      },
+      {
+        "name": "src_pod",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(netobs_pod_stage_latency_labeled_seconds_count{src_namespace=\"$src_namespace\"}, src_pod)",
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false,
+        "label": "Pod"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Pod drill-down: $src_namespace / $src_pod",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Latency p99 by stage",
+      "description": "선택 pod 의 수신/송신 stage 별 p99 지연. netobs_pod_stage_latency_labeled_seconds 를 stage 로 분해한다.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, stage) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m])))",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Network throughput by direction/layer",
+      "description": "선택 pod 의 방향(ingress/egress) 과 layer(nic/l4) 별 바이트 처리율.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (direction, layer) (rate(netobs_pod_bytes_total{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m]))",
+          "legendFormat": "{{direction}}/{{layer}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Drop rate by reason",
+      "description": "선택 pod 의 drop reason 별 초당 drop 수. netobs_drop_events_flow_total 기반.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (drop_reason, drop_category) (rate(netobs_drop_events_flow_total{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m]))",
+          "legendFormat": "{{drop_reason}} ({{drop_category}})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "GPU utilization & memory",
+      "description": "선택 pod 의 GPU 사용률 p95 와 GPU 메모리 사용 비율. GPU 워크로드 미귀속 시 graceful 하게 비어 있다.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "pod:gpu_util_p95:5m{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}",
+          "legendFormat": "util_p95",
+          "refId": "A"
+        },
+        {
+          "expr": "pod:gpu_memory_utilization_ratio:5m{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"} * 100",
+          "legendFormat": "mem_util%",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Latency p99 adaptive anomaly band (rolling avg ± 2σ)",
+      "description": "#178 적응형 이상 하이라이트. 선택 pod 의 p99 가 자신의 1h rolling 평균 + 2σ 밴드를 넘으면 이상으로 본다. cluster z-score recording rule(adaptive) 과 달리 pod 자기 기준선으로 self-calibrating 하며 ML 없이 PromQL subquery 로만 산정한다.",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "avg_over_time((histogram_quantile(0.99, sum by (le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m]))))[1h:5m])",
+          "legendFormat": "rolling avg(1h)",
+          "refId": "B"
+        },
+        {
+          "expr": "avg_over_time((histogram_quantile(0.99, sum by (le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m]))))[1h:5m]) + 2 * stddev_over_time((histogram_quantile(0.99, sum by (le) (rate(netobs_pod_stage_latency_labeled_seconds_bucket{src_namespace=\"$src_namespace\",src_pod=\"$src_pod\"}[5m]))))[1h:5m])",
+          "legendFormat": "avg + 2σ (anomaly 상한)",
+          "refId": "C"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/gpuobs/base/servicemonitor.yaml
+++ b/deploy/gpuobs/base/servicemonitor.yaml
@@ -22,13 +22,16 @@ spec:
       # #178 stale 시리즈 근본 정리. gpuobs-agent 는 GPU 노드당 1 인 DaemonSet 이라 node 라벨이 없는
       # self-health 메트릭 (gpuobs_dcgm_available 등) 은 pod/instance 로만 인스턴스가 구분된다. netobs
       # 와 동일하게 __meta_kubernetes_pod_node_name 을 node 로 부여하고 honorLabels: true 로 data
-      # 메트릭의 node (관측 노드) 를 보존한 뒤 pod 와 instance 를 labeldrop 해 재시작 stale churn 을
-      # 제거한다.
+      # 메트릭의 node (관측 노드) 를 보존한다. agent pod 라벨은 merge 前 relabelings 단계에서 labeldrop
+      # 해 자체 pod 를 emit 하는 메트릭과의 충돌 (exported_pod 잔존) 을 원천 차단하고, instance 와 충돌로
+      # 밀린 exported_* 는 metricRelabelings 로 제거한다. netobs 와 동일 패턴으로 통일한다.
       honorLabels: true
       relabelings:
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           targetLabel: node
           action: replace
+        - regex: pod
+          action: labeldrop
       metricRelabelings:
-        - regex: pod|instance
+        - regex: instance|exported_pod|exported_instance|exported_namespace|exported_node
           action: labeldrop

--- a/deploy/gpuobs/base/servicemonitor.yaml
+++ b/deploy/gpuobs/base/servicemonitor.yaml
@@ -19,3 +19,16 @@ spec:
       path: /metrics
       interval: 15s
       scrapeTimeout: 10s
+      # #178 stale 시리즈 근본 정리. gpuobs-agent 는 GPU 노드당 1 인 DaemonSet 이라 node 라벨이 없는
+      # self-health 메트릭 (gpuobs_dcgm_available 등) 은 pod/instance 로만 인스턴스가 구분된다. netobs
+      # 와 동일하게 __meta_kubernetes_pod_node_name 을 node 로 부여하고 honorLabels: true 로 data
+      # 메트릭의 node (관측 노드) 를 보존한 뒤 pod 와 instance 를 labeldrop 해 재시작 stale churn 을
+      # 제거한다.
+      honorLabels: true
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+          action: replace
+      metricRelabelings:
+        - regex: pod|instance
+          action: labeldrop

--- a/deploy/netobs/base/servicemonitor.yaml
+++ b/deploy/netobs/base/servicemonitor.yaml
@@ -22,15 +22,21 @@ spec:
       # #178 stale 시리즈 근본 정리. pod 와 instance 는 agent pod 재시작마다 값이 바뀌어 (pod 이름
       # 랜덤 suffix, instance IP:port) 메트릭에 stale 시리즈 churn 을 유발한다. netobs-agent 는
       # DaemonSet (노드당 1) 이라 node 라벨이 없는 self-health / legacy 메트릭 (netobs_bpf_program_
-      # attach_total, netobs_informer_sync_lag_seconds 등) 은 pod/instance 로만 인스턴스가 구분되므로,
-      # 먼저 __meta_kubernetes_pod_node_name 을 node 로 부여해 노드별로 구분되게 한다. honorLabels:
-      # true 로 두어 data 메트릭이 이미 보유한 node (관측 노드 = 자기 노드) 가 보존되어 exported_node
-      # 로 밀려나지 않게 한 뒤 pod 와 instance 를 labeldrop 한다.
+      # attach_total 등) 은 pod/instance 로만 인스턴스가 구분되므로, __meta_kubernetes_pod_node_name 을
+      # node 로 부여해 노드별로 구분되게 하고 honorLabels: true 로 data 메트릭의 node (관측 노드) 를
+      # 보존한다 (exported_node 회피). agent pod 라벨은 metricRelabelings 가 아니라 relabelings 단계
+      # (merge 前) 에서 labeldrop 해, 자체 pod 를 emit 하는 메트릭 (netobs_tcp_state_* 의 워크로드 pod)
+      # 과 충돌해 워크로드 pod 가 사라지고 agent pod 가 exported_pod 로 남는 것을 원천 차단한다.
+      # tcp_state 의 워크로드 pod 는 scraped 라벨이라 본 labeldrop 에 영향받지 않고 보존된다. instance 는
+      # 어떤 netobs 메트릭도 자체 emit 하지 않아 (agent IP:port) 전역 drop 하고, 충돌로 밀린 exported_*
+      # (예: tcp_state 의 exported_namespace) 도 함께 제거한다.
       honorLabels: true
       relabelings:
         - sourceLabels: [__meta_kubernetes_pod_node_name]
           targetLabel: node
           action: replace
+        - regex: pod
+          action: labeldrop
       metricRelabelings:
-        - regex: pod|instance
+        - regex: instance|exported_pod|exported_instance|exported_namespace|exported_node
           action: labeldrop

--- a/deploy/netobs/base/servicemonitor.yaml
+++ b/deploy/netobs/base/servicemonitor.yaml
@@ -19,3 +19,18 @@ spec:
       path: /metrics
       interval: 15s
       scrapeTimeout: 10s
+      # #178 stale 시리즈 근본 정리. pod 와 instance 는 agent pod 재시작마다 값이 바뀌어 (pod 이름
+      # 랜덤 suffix, instance IP:port) 메트릭에 stale 시리즈 churn 을 유발한다. netobs-agent 는
+      # DaemonSet (노드당 1) 이라 node 라벨이 없는 self-health / legacy 메트릭 (netobs_bpf_program_
+      # attach_total, netobs_informer_sync_lag_seconds 등) 은 pod/instance 로만 인스턴스가 구분되므로,
+      # 먼저 __meta_kubernetes_pod_node_name 을 node 로 부여해 노드별로 구분되게 한다. honorLabels:
+      # true 로 두어 data 메트릭이 이미 보유한 node (관측 노드 = 자기 노드) 가 보존되어 exported_node
+      # 로 밀려나지 않게 한 뒤 pod 와 instance 를 labeldrop 한다.
+      honorLabels: true
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+          action: replace
+      metricRelabelings:
+        - regex: pod|instance
+          action: labeldrop

--- a/deploy/rca-summarizer/base/servicemonitor.yaml
+++ b/deploy/rca-summarizer/base/servicemonitor.yaml
@@ -21,3 +21,8 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+      # #178 stale 시리즈 근본 정리. rca-summarizer 는 단일 replica Deployment 라 pod/instance 를 drop
+      # 해도 collision 이 없고, 재시작 시 바뀌던 pod/instance stale churn 만 제거된다.
+      metricRelabelings:
+        - regex: pod|instance
+          action: labeldrop


### PR DESCRIPTION
## 배경
통합 대시보드의 계층 시각화와 z-score 하이라이트와 시간대 추이와 이벤트 알림은 구현돼 있다. stale 라벨 근본 정리와 적응형 이상 감지와 pod 중심 통합 뷰가 잔여 고도화 항목이라 본 PR로 마무리한다.

## 변경 사항
- netobs와 gpuobs와 correlation과 rca-summarizer ServiceMonitor에 metricRelabelings labeldrop을 추가해 재시작마다 바뀌던 pod와 instance 라벨이 유발하던 stale 시리즈 churn을 근본 제거한다
- netobs와 gpuobs는 DaemonSet이라 node 라벨이 없는 self-health 메트릭이 pod/instance로만 인스턴스가 구분된다. __meta_kubernetes_pod_node_name을 node로 부여하고 honorLabels로 data 메트릭의 node를 보존(exported_node 회피)한 뒤 pod/instance를 drop해 collision을 막는다. correlation과 rca-summarizer는 단일 replica라 labeldrop만 적용한다
- netobs와 gpuobs와 correlation에 분산된 pod 패널을 src_namespace와 src_pod 변수 기반 단일 pod drill-down 대시보드로 통합해 한 pod의 stage latency p99와 방향별 throughput와 drop reason별 drop과 GPU 사용률/메모리를 한 화면에서 동시에 본다
- 적응형 이상 하이라이트로 cluster z-score recording rule과 별개로 pod 자기 기준선의 1h rolling 평균 + 2σ 밴드를 PromQL subquery로 산정해 ML 없이 self-calibrating anomaly를 노출한다

## 검증
- dev 라이브에서 netobs data 메트릭의 pod와 instance 라벨이 제거되고 exported_node가 생기지 않으며 node가 보존됨을 확인한다. node 없는 netobs 시리즈가 1284에서 1로 줄어 self-health에 node가 부여되고 collision이 없음을 확인한다
- pod-drilldown 대시보드 ConfigMap이 grafana_dashboard 라벨로 생성되고 단일 pod의 latency와 drop과 network와 GPU 패널 PromQL이 라이브에서 유효함을 확인한다
- 전체 kustomize overlay 빌드와 저장소 go build / go test가 통과한다

## 비목표
ML 모델 학습 파이프라인 구축은 본 PR 범위 밖이며, 적응형 이상은 기존 z-score recording rule과 PromQL rolling 밴드로 갈음한다.

## 수용 조건
- stale pod와 instance 라벨 시리즈가 더 이상 노출되지 않음을 확인
- pod 중심 drill-down에서 단일 pod의 latency와 drop과 GPU와 network 지표 동시 확인 가능

Closes #178
