### PR TITLE
chore(security): correlation-exporter와 swagger-ui를 NetworkPolicy로 내부 전용 강제

### DIFF
--- a/deploy/correlation/base/kustomization.yaml
+++ b/deploy/correlation/base/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - servicemonitor.yaml
+  - networkpolicy.yaml
   - prometheus-rule.yaml

--- a/deploy/correlation/base/networkpolicy.yaml
+++ b/deploy/correlation/base/networkpolicy.yaml
@@ -1,0 +1,32 @@
+# correlation-exporter 는 무인증 API 라 네트워크 계층에서 내부 접근만 허용한다 (#217). 허용 출처는
+# 세 갈래다. 같은 네임스페이스 pod (rca-summarizer 와 workload-injector 와 swagger-ui), Prometheus
+# scrape 의 monitoring 네임스페이스, 그리고 `observability.netobs/api-consumer: "true"` 라벨을 부여한
+# 소비 네임스페이스 (프론트엔드 대시보드 등 미래 소비처는 네임스페이스 라벨만 추가하면 된다).
+# kubelet 의 liveness/readiness httpGet probe 는 로컬 노드 host 발신이라 Cilium 이 정책과 무관하게
+# 허용한다. egress 는 본 이슈 범위 외라 제한하지 않는다 (policyTypes 에 Egress 미포함).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: correlation-exporter
+  labels:
+    app.kubernetes.io/name: correlation-exporter
+    app.kubernetes.io/part-of: ebpf-project
+    app.kubernetes.io/component: correlation-exporter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: correlation-exporter
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+        - namespaceSelector:
+            matchLabels:
+              observability.netobs/api-consumer: "true"
+      ports:
+        - port: 9830
+          protocol: TCP

--- a/deploy/correlation/base/service.yaml
+++ b/deploy/correlation/base/service.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/part-of: ebpf-project
     app.kubernetes.io/component: correlation-exporter
 spec:
+  # 무인증 API 라 공인 노출 (NodePort / LoadBalancer 승격) 을 금지한다 (#217). 내부 소비만 전제하며
+  # 접근 제한은 NetworkPolicy 가 강제한다.
+  type: ClusterIP
   selector:
     app.kubernetes.io/name: correlation-exporter
   ports:

--- a/deploy/swagger-ui/kustomization.yaml
+++ b/deploy/swagger-ui/kustomization.yaml
@@ -11,3 +11,4 @@ namespace: ebpf-project
 resources:
   - deployment.yaml
   - service.yaml
+  - networkpolicy.yaml

--- a/deploy/swagger-ui/networkpolicy.yaml
+++ b/deploy/swagger-ui/networkpolicy.yaml
@@ -1,5 +1,7 @@
-# swagger-ui 는 correlation-exporter 스펙을 노출하는 문서 UI 라 동일한 내부 전용 정책을 적용한다
-# (#217). 허용 출처 구성은 correlation-exporter NetworkPolicy 와 같다.
+# swagger-ui 는 correlation-exporter 스펙을 노출하는 문서 UI 라 내부 전용 정책을 적용한다 (#217).
+# 정적 UI 라 Prometheus scrape 대상이 아니므로 correlation-exporter 정책과 달리 monitoring
+# 네임스페이스는 허용하지 않는다 (최소 권한). 운영자 접근은 CNI 데이터패스를 우회하는 kubectl
+# port-forward 로 정책과 무관하게 가능하다.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -18,9 +20,6 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: monitoring
         - namespaceSelector:
             matchLabels:
               observability.netobs/api-consumer: "true"

--- a/deploy/swagger-ui/networkpolicy.yaml
+++ b/deploy/swagger-ui/networkpolicy.yaml
@@ -1,0 +1,29 @@
+# swagger-ui 는 correlation-exporter 스펙을 노출하는 문서 UI 라 동일한 내부 전용 정책을 적용한다
+# (#217). 허용 출처 구성은 correlation-exporter NetworkPolicy 와 같다.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: swagger-ui
+  namespace: ebpf-project
+  labels:
+    app.kubernetes.io/name: swagger-ui
+    app.kubernetes.io/component: api-docs
+    app.kubernetes.io/part-of: ebpf-project
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: swagger-ui
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+        - namespaceSelector:
+            matchLabels:
+              observability.netobs/api-consumer: "true"
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -33,6 +33,16 @@
 | 통합 대시보드·알림 표시 | 프론트엔드 영역 | 범위 외 |
 | 부하테스트 자동화 | `workload-injector` (dev 전용 LoadScenario CRD) 가 담당 | 범위 외 |
 
+## 접근 제어
+
+correlation-exporter API 는 무인증이므로 클러스터 내부 전용으로 운용하며 공인 노출을 금지한다. Service 는 `type: ClusterIP` 로 고정하고 NodePort 나 LoadBalancer 로 승격하지 않으며, 노드에서 socat 같은 임시 프록시로 공인 IP 에 노출하는 것도 금지한다. 접근은 NetworkPolicy 가 강제하며 허용 출처는 다음과 같다.
+
+- `ebpf-project` 네임스페이스 내부 pod (rca-summarizer 와 workload-injector 와 swagger-ui)
+- `monitoring` 네임스페이스 (Prometheus scrape)
+- `observability.netobs/api-consumer: "true"` 라벨을 부여한 네임스페이스. 프론트엔드 대시보드 등 새 소비처는 해당 네임스페이스에 이 라벨을 추가해 허용한다
+
+외부 노출이 요건이 되는 시점에는 토큰이나 mTLS 기반 인증 도입과 함께 별도 이슈로 재검토한다.
+
 ## 스펙 생성 규약
 
 swagger 스펙은 swaggo 어노테이션이 단일 소스다. 임베디드 스펙(`internal/correlation/api/docs/`)과 통합본(`docs/api/openapi.yaml`)은 모두 `make swag-init` 과 `make swag-merge` 의 생성물이며, 재생성 누락은 `make check-swagger-drift` 가 감지한다.


### PR DESCRIPTION
## 개요

correlation-exporter API가 무인증에 CORS `*`로 응답하지만 접근을 강제하는 NetworkPolicy가 없었다. 프론트 대시보드도 클러스터 내부 배포를 전제하므로 인증 인프라 대신 네트워크 계층에서 내부 접근만 허용하고 공인 노출을 구조적으로 차단한다. CNI가 Cilium이라 NetworkPolicy가 실제 집행됨을 전제로 한다.

## 작업 내용

- correlation-exporter ingress를 세 출처로 제한하는 NetworkPolicy를 추가한다. 같은 네임스페이스 pod(rca-summarizer와 workload-injector와 swagger-ui), Prometheus scrape의 `monitoring` 네임스페이스, `observability.netobs/api-consumer: "true"` 라벨을 부여한 소비 네임스페이스를 허용하며, 프론트엔드 등 새 소비처는 네임스페이스 라벨 추가만으로 허용된다
- swagger-ui에도 동일 구성의 ingress 제한을 적용한다
- Service에 `type: ClusterIP`를 명시해 NodePort나 LoadBalancer 승격을 금지하고, `docs/api/coverage.md`에 공인 노출 금지와 허용 출처 규약을 기재한다
- CORS `Access-Control-Allow-Origin` 화이트리스트는 내부 배포 origin 확정 후 판단하기로 하고 본 PR에서는 다루지 않는다
- egress 제한과 토큰이나 mTLS 기반 인증은 비목표대로 다루지 않는다

## 검증

클러스터에 정책을 적용하고 접근 경로 전수를 확인했다.

- `default` 네임스페이스 pod에서 correlation-exporter와 swagger-ui 접근이 모두 timeout으로 차단된다
- 같은 네임스페이스 pod와 `observability.netobs/api-consumer: "true"` 라벨 네임스페이스 pod의 접근은 HTTP 200으로 허용된다
- Prometheus scrape가 `up{job="correlation-exporter"}=1`로 유지되고 rca-summarizer의 snapshot fetch 에러가 없다
- kubelet의 liveness/readiness probe가 정책과 무관하게 통과해 pod Ready가 유지된다
- 이미지 변경이 없어 버전 bump 없이 라이브 `1.6.1`을 유지한다

Closes #217
