### PR TITLE
chore(security): netobs-agent 권한을 drop ALL 후 최소 capabilities로 축소

### DIFF
--- a/deploy/netobs/base/daemonset.yaml
+++ b/deploy/netobs/base/daemonset.yaml
@@ -52,9 +52,29 @@ spec:
             - name: metrics
               containerPort: 9810
               protocol: TCP
+          # #216 privileged 를 제거하고 drop ALL 후 최소 capabilities 로 축소한다. BPF 는 bpf()
+          # syscall (프로그램 로드와 map), PERFMON 은 kprobe/kretprobe 의 perf_event_open, SYSLOG 는
+          # kptr_restrict=1 상태에서 /proc/kallsyms 실주소 읽기 (drop stack symbol resolve) 에 필요하다.
+          # SYS_ADMIN 은 Ubuntu 커널 전용 kernel.perf_event_paranoid=4 대응이다. 이 레벨은 CAP_PERFMON
+          # 까지 무력화해 perf_kprobe PMU 생성이 permission denied 로 실패함을 dev canary 에서 실측했다
+          # (표준 커널 의 paranoid<=2 환경 에서는 SYS_ADMIN 없이 PERFMON 만으로 충분해 제거 가능하다).
+          # RemoveMemlock 은 kernel 5.11+ 의 memcg 기반 BPF 계정 감지 시 no-op 이라 CAP_SYS_RESOURCE 가
+          # 불필요하고, cgroup 기반 Pod 귀속이라 gpuobs 의 CAP_SYS_PTRACE 도 불필요하다.
+          # readOnlyRootFilesystem 은 BPF 산출물이 바이너리에 임베드되고 로그가 stdout 이라 디스크
+          # 쓰기가 없어 함께 강화한다. privileged 대비 전체 capability 와 장치 접근, LSM/seccomp 해제가
+          # 사라져 blast radius 가 명시된 4 종 으로 한정된다.
           securityContext:
-            privileged: true
-            allowPrivilegeEscalation: true
+            privileged: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - BPF
+                - PERFMON
+                - SYSLOG
+                - SYS_ADMIN
           livenessProbe:
             httpGet:
               path: /healthz
@@ -74,8 +94,10 @@ spec:
             limits:
               memory: 512Mi
           volumeMounts:
+            # #216 map/link pin 을 쓰지 않아 (fd 기반 lifetime) 쓰기가 불필요해 read-only 로 강등한다.
             - name: sys-fs-bpf
               mountPath: /sys/fs/bpf
+              readOnly: true
             - name: sys-kernel-btf
               mountPath: /sys/kernel/btf
               readOnly: true

--- a/deploy/netobs/base/daemonset.yaml
+++ b/deploy/netobs/base/daemonset.yaml
@@ -67,6 +67,13 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            # seccomp 를 암묵 상태 (kubelet seccompDefault 의존) 로 두지 않고 RuntimeDefault 로 명시
+            # 고정한다. 런타임 기본 프로파일은 bpf 와 perf_event_open 을 capability 게이팅으로 허용
+            # (CAP_BPF / CAP_PERFMON / CAP_SYS_ADMIN 보유 시) 하므로 아래 add 집합과 함께 정상
+            # 동작함을 dev canary 의 attach 전수로 실측했다. kubelet 이 향후 seccompDefault 를 켜도
+            # 동작이 변하지 않는다.
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## 개요

netobs-agent DaemonSet이 `privileged: true`와 `allowPrivilegeEscalation: true`로 구동돼 blast radius가 전체 capability와 장치 접근, LSM/seccomp 해제까지 열려 있었다. gpuobs-agent가 이미 drop ALL 후 최소 capabilities로 동일한 eBPF attach를 수행하고 있어 netobs도 실제 필요 집합만 남긴다.

## 작업 내용

- `privileged: true`를 제거하고 `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`로 전환한 뒤 `BPF`(프로그램 로드와 map), `PERFMON`(kprobe/kretprobe의 perf_event_open), `SYSLOG`(`kptr_restrict=1` 상태의 `/proc/kallsyms` 실주소 읽기), `SYS_ADMIN` 4종만 add한다
- `SYS_ADMIN`은 Ubuntu 커널 전용 `kernel.perf_event_paranoid=4`가 CAP_PERFMON까지 무력화해 `perf_kprobe PMU` 생성이 permission denied로 실패함을 dev canary에서 실측해 추가했다. 표준 커널(paranoid 2 이하)에서는 제거 가능함을 주석에 명시한다
- `RemoveMemlock`은 kernel 5.11+의 memcg 기반 BPF 계정 감지 시 no-op이라 `CAP_SYS_RESOURCE`가 불필요하고, cgroup 기반 Pod 귀속이라 gpuobs의 `CAP_SYS_PTRACE`도 불필요함을 확인했다
- BPF 산출물이 바이너리에 임베드되고 로그가 stdout이라 디스크 쓰기가 없어 `readOnlyRootFilesystem: true`를 함께 강화한다
- hostPath 6종을 재점검해 map/link pin을 쓰지 않는 `sys-fs-bpf`를 read-only로 강등한다. 나머지 5종은 이미 read-only이며 경로 구성은 비목표대로 변경하지 않는다

## 검증

- dev canary에서 1차 집합(BPF/PERFMON/SYSLOG)의 attach 실패를 `perf_event_paranoid=4` 원인으로 실측하고 `SYS_ADMIN` 추가로 해소했다
- prod 3노드 전부에서 kprobe/kretprobe 23종 attach 성공과 에러 0건, `netobs_bpf_program_loaded` 23종 전부 1을 확인했다
- `kptr_restrict=1` 상태에서 kallsyms 실주소 기반 drop stack resolver가 동작하고 tracefs의 drop reason 86종 파싱이 정상임을 확인했다
- 전 stage 이벤트가 3노드에서 계속 수집됨을 확인했고, `readOnlyRootFilesystem` 적용 후 rollout과 probe가 정상이다
- 매니페스트만의 변경이라 버전 bump 없이 라이브 `1.6.1`을 유지한다

Closes #216
