### PR TITLE
chore(dashboards): #244 이후 의미 불일치 텍스트 정정과 신규 rule 패널 반영

### DIFF
--- a/deploy/dashboards/gpu-network-correlation.json
+++ b/deploy/dashboards/gpu-network-correlation.json
@@ -734,10 +734,7 @@
         "x": 0,
         "y": 63
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "min": 0,

--- a/deploy/dashboards/gpu-network-correlation.json
+++ b/deploy/dashboards/gpu-network-correlation.json
@@ -215,7 +215,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "GPU idle cause weight per victim ($src_namespace/$src_pod)",
-      "description": "#101 victim 단위 GPU idle 5 cause 가중치 분포. pod:gpu_idle_cause_weight:5m 5 cause (pcie_saturation 와 cpu_throttle 와 memory_pressure 와 network_pressure 와 host_compute_stall) 를 victim 별 stacked time-series 로 표시한다. 각 cause 는 고정 색상으로 운영자가 secondary 와 tertiary cause 까지 한눈에 비교 가능하다. 시리즈 의 stacked 높이 합이 1.0 에 가까우면 idle 게이팅 활성 시간대 이며 비어 있으면 GPU 가 idle 이 아니거나 cause 합이 0 인 상태다. dimension 4 종 과 cause 5 종 매핑 은 docs/observability/gpu-idle-dominant-cause.md 의 매핑 표 참조.",
+      "description": "#101 victim 단위 GPU idle 6 cause 가중치 분포. pod:gpu_idle_cause_weight:5m 의 6 cause (pcie_saturation, cpu_throttle, memory_pressure, network_pressure, host_compute_stall, cgroup_contention) 를 victim 별 stacked time-series 로 표시한다. 주의: victim 체인은 절대 압박 score 기반이라 #244 의 rise 기반 cluster dominant 와 산정 기반이 다르다. 상시 포화 pod 가 여기 에는 남고 cluster dominant 에는 없는 것은 버그가 아니라 설계다. stacked 높이 합이 1.0 에 가까우면 idle 게이팅 활성 시간대이며 비어 있으면 GPU 가 idle 이 아니거나 cause 합이 0 인 상태다.",
       "datasource": "${datasource}",
       "gridPos": {
         "h": 10,
@@ -722,6 +722,38 @@
           }
         }
       }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Node dominant cause ($node)",
+      "description": "node:gpu_idle_dominant_cause:5m{node=\"$node\"} (#256). 노드 단위 GPU 유휴 dominant cause 로, cluster (rise 기반) 와 victim (절대 기반) 사이의 노드 scope 계층이다. gpu-rca API 의 dominant_cause 와 동일 시리즈이며, cause 라벨별 시리즈로 시간축 상 dominant 전이를 본다.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "custom": {
+            "lineInterpolation": "stepBefore"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "node:gpu_idle_dominant_cause:5m{node=\"$node\"}",
+          "legendFormat": "{{cause}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "annotations": {

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -2865,10 +2865,7 @@
         "x": 12,
         "y": 35
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "min": 0,
@@ -2879,22 +2876,22 @@
       },
       "targets": [
         {
-          "expr": "node:cpu_health_score:5m{node=\"$node\"}",
+          "expr": "node:cpu_health_score:5m{node=~\"$node\"}",
           "legendFormat": "cpu",
           "refId": "A"
         },
         {
-          "expr": "node:gpu_health_score:5m{node=\"$node\"}",
+          "expr": "node:gpu_health_score:5m{node=~\"$node\"}",
           "legendFormat": "gpu",
           "refId": "B"
         },
         {
-          "expr": "node:memory_health_score:5m{node=\"$node\"}",
+          "expr": "node:memory_health_score:5m{node=~\"$node\"}",
           "legendFormat": "memory",
           "refId": "C"
         },
         {
-          "expr": "node:network_health_score:5m{node=\"$node\"}",
+          "expr": "node:network_health_score:5m{node=~\"$node\"}",
           "legendFormat": "network",
           "refId": "D"
         }
@@ -2911,10 +2908,7 @@
         "x": 0,
         "y": 145
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "min": 0,

--- a/deploy/dashboards/overview.json
+++ b/deploy/dashboards/overview.json
@@ -97,7 +97,7 @@
       "id": 1,
       "type": "stat",
       "title": "GPU health",
-      "description": "cluster:gpu_health_score:5m. 1 healthy, 0 worst. GPU 사용률(node:gpu_util_ratio:5m) cluster 평균 기준.",
+      "description": "cluster:gpu_health_score:5m. 1 healthy, 0 worst. #273 재정의: 사용률이 아니라 하드웨어 이상 신호 (thermal score, 유의미 NVML 오류율, 성능성 throttle 활성) 기반이라 유휴 GPU 는 health 를 깎지 않는다. worst 노드 기준 (min(node:gpu_health_score:5m)).",
       "datasource": "${datasource}",
       "gridPos": {
         "h": 6,
@@ -307,7 +307,7 @@
       "id": 4,
       "type": "stat",
       "title": "Memory health",
-      "description": "cluster:memory_health_score:5m. Pod 단위 memory_pressure_score p95 의 inversion.",
+      "description": "cluster:memory_health_score:5m. #274 재정의: pod limit 비율 p95 가 아니라 node_exporter 실측 (1 - MemAvailable/MemTotal) 의 worst 노드 역수다. tight-limit 관측 인프라 pod 가 health 를 지배하지 않는다.",
       "datasource": "${datasource}",
       "gridPos": {
         "h": 6,
@@ -377,7 +377,7 @@
       "id": 150,
       "type": "stat",
       "title": "GPU idle dominant cause",
-      "description": "cluster:gpu_idle_dominant_cause:5m. 5 cause weight 의 최대 cause 1 종을 노출. GPU idle 게이팅 (>0.5) 이 트리거되고 5 cause 합이 양수일 때만 emit 되며, idle 아님 또는 5 cause 모두 0 인 시간대는 N/A 로 표시된다.",
+      "description": "cluster:gpu_idle_dominant_cause:5m. 9 cause weight 의 최대 cause 1 종을 노출. #244 부터 pod 계열 5 cause (cpu_throttle, memory_pressure, network_pressure, cgroup_contention, host_compute_stall) 의 base 는 GPU 유휴 노드 스코프 rise (유휴 시점 상승분) 이고 device 계열 4 cause (pcie_saturation, dcgm_pcie_replay, nccl_collective_stall, thermal) 는 절대 신호다. GPU idle 게이팅 (>0.5) 과 cause 합 노이즈 하한 (>0.05) 을 지나야 emit 되며, 미충족 시간대는 N/A 다.",
       "datasource": "${datasource}",
       "gridPos": {
         "h": 4,
@@ -708,7 +708,7 @@
       "datasource": "${datasource}",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 35
       },
@@ -2635,8 +2635,8 @@
         {
           "id": 801,
           "type": "timeseries",
-          "title": "GPU idle cause weight (5 cause stacked)",
-          "description": "avg by(cause) (pod:gpu_idle_cause_weight:5m) 의 5 cause (pcie_saturation과 network_pressure과 cpu_throttle과 memory_pressure과 host_compute_stall) weight를 cluster 평균으로 집계해 stacked로 표시한다. victim 단위 raw 메트릭을 cause 차원으로 avg 집계해 stacked 합이 victim 수에 비례해 부풀려지던 문제를 해소한다. 개별 cause weight는 0-1 범위이며 상대 크기로 어느 cause가 dominant인지 한눈에 식별한다. dev cluster의 RTX 3090 환경에서 nccl_collective_stall과 dcgm_pcie_replay 슬롯은 0 weight로 emit된다.",
+          "title": "GPU idle cause weight (victim 단위, 절대 압박 기반)",
+          "description": "avg by(cause) (pod:gpu_idle_cause_weight:5m) 의 victim 단위 6 cause (pcie_saturation, cpu_throttle, memory_pressure, network_pressure, host_compute_stall, cgroup_contention) weight 를 cluster 평균으로 stacked 표시한다. 주의: victim 체인은 절대 압박 score 기반이고 옆의 Dominant cause indicator (cluster) 는 #244 의 rise (유휴 시점 상승분) 기반이라 산정 기반이 다르다. 상시 포화 pod 는 여기에는 나타나되 cluster dominant 에는 나타나지 않을 수 있으며 이는 버그가 아니라 설계다 (#244 비목표로 victim 체인 유지). rise 관점의 pod 단위 drill-down 은 pod:cpu_throttle_score_rise:5m 등 pod:*_score_rise:5m 7종을 Explore 에서 조회한다.",
           "datasource": "${datasource}",
           "gridPos": {
             "h": 8,
@@ -2696,7 +2696,7 @@
           "id": 802,
           "type": "stat",
           "title": "Dominant cause indicator",
-          "description": "cluster:gpu_idle_dominant_cause:5m 의 dominant cause 1종을 노출한다. 5 cause weight 중 최대값 cause가 표시되며 weight 시리즈가 idle 게이팅으로 emit되지 않는 시간대는 N/A다.",
+          "description": "cluster:gpu_idle_dominant_cause:5m 의 dominant cause 1종을 노출한다. 9 cause weight 중 최대값 cause 가 표시되며 pod 계열 5종은 rise 기반 (#244), device 계열 4종은 절대 신호다. weight 시리즈가 idle 게이팅 또는 노이즈 하한 (합 >0.05) 으로 emit 되지 않는 시간대는 N/A 다.",
           "datasource": "${datasource}",
           "gridPos": {
             "h": 8,
@@ -2744,7 +2744,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 146
+        "y": 154
       },
       "panels": [
         {
@@ -2851,6 +2851,106 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "id": 813,
+      "type": "timeseries",
+      "title": "Node health 4차원 ($node)",
+      "description": "node:{cpu,gpu,memory,network}_health_score:5m (#264, #273, #274). 1 healthy, 0 worst. gpu 는 하드웨어 이상 신호 기반 (#273), memory 는 node_exporter 실측 기반 (#274) 이라 유휴 GPU 나 tight-limit pod 가 노드 health 를 깎지 않는다. node/{node} API 의 health 필드와 동일 시리즈다.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "node:cpu_health_score:5m{node=\"$node\"}",
+          "legendFormat": "cpu",
+          "refId": "A"
+        },
+        {
+          "expr": "node:gpu_health_score:5m{node=\"$node\"}",
+          "legendFormat": "gpu",
+          "refId": "B"
+        },
+        {
+          "expr": "node:memory_health_score:5m{node=\"$node\"}",
+          "legendFormat": "memory",
+          "refId": "C"
+        },
+        {
+          "expr": "node:network_health_score:5m{node=\"$node\"}",
+          "legendFormat": "network",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "id": 814,
+      "type": "timeseries",
+      "title": "GPU idle cause rise (cluster, dominant 의 산정 base)",
+      "description": "cluster:gpu_idle_{cpu_throttle,memory_pressure,network_pressure,cgroup_contention,host_compute_stall}_rise:5m (#244). pod 계열 cause 의 GPU 유휴 노드 스코프 baseline 대비 상승분으로, 위 Dominant cause indicator 가 실제로 소비하는 base 시리즈다. 상시 포화 신호는 0 에 수렴하고 유휴와 함께 나타난 신규 압박만 남는다. pod 단위 rise drill-down 은 pod:*_score_rise:5m 을 Explore 에서 조회한다.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 145
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "custom": {
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "cluster:gpu_idle_cpu_throttle_rise:5m",
+          "legendFormat": "cpu_throttle",
+          "refId": "A"
+        },
+        {
+          "expr": "cluster:gpu_idle_memory_pressure_rise:5m",
+          "legendFormat": "memory_pressure",
+          "refId": "B"
+        },
+        {
+          "expr": "cluster:gpu_idle_network_pressure_rise:5m",
+          "legendFormat": "network_pressure",
+          "refId": "C"
+        },
+        {
+          "expr": "cluster:gpu_idle_cgroup_contention_rise:5m",
+          "legendFormat": "cgroup_contention",
+          "refId": "D"
+        },
+        {
+          "expr": "cluster:gpu_idle_host_compute_stall_rise:5m",
+          "legendFormat": "host_compute_stall",
+          "refId": "E"
         }
       ]
     }


### PR DESCRIPTION
## 개요

대시보드 감사 결과 깨진 패널 참조는 없으나, #244가 cluster cause weight의 base를 절대 압박에서 GPU 유휴 노드 스코프 rise로 바꾼 뒤 패널 제목·설명이 "5 cause"(실제 9종)와 절대 압박 의미로 남아 있었고 `cgroup_contention`이 누락돼 있었다. 특히 절대 압박 기반인 victim weight 패널과 rise 기반인 dominant cause 패널이 다른 산정 기반인데 같은 시리즈처럼 설명되어 운영자가 두 패널의 불일치를 버그로 오인할 수 있었다. 또한 신설 rule 18종이 어느 대시보드에도 반영되지 않았다.

## 변경 내용

- overview와 gpu-network-correlation의 GPU idle cause 패널 4곳을 정정한다. cause 수를 9종으로 바로잡고 `cgroup_contention`을 포함하며, victim weight(절대 압박)와 cluster dominant(rise)의 산정 기반 차이와 "상시 포화 pod가 victim에는 남고 cluster dominant에는 없는 것은 설계"임을 명시한다
- 머지된 #273과 #274를 반영해 GPU health 카드(사용률이 아닌 하드웨어 이상 신호 기반)와 Memory health 카드(node_exporter 실측 기반) 설명을 갱신한다
- 신규 패널 3개를 추가한다. overview 노드 row의 Node health 4차원(`node:*_health_score:5m`, node/{node} API와 동일 시리즈), GPU idle 시나리오 row의 cluster rise 5종 stacked(dominant가 실제로 소비하는 base), gpu-network-correlation의 Node dominant cause(`node:gpu_idle_dominant_cause:5m`, gpu-rca API와 동일 시리즈)
- pod rise 7종은 개별 패널 없이 관련 패널 설명의 Explore drill-down 쿼리로만 연결해 대시보드 밀도를 유지한다

## 검증

- 두 대시보드 JSON 유효성 확인, 신규 패널 쿼리 6종이 dev에서 전부 실데이터를 반환함을 확인(죽은 패널 없음)
- `make deploy-dashboards` 적용 후 live configmap에서 제목·설명 정정과 신규 패널 반영을 전수 확인. dashboards는 dev/prod 분기 없는 클러스터 공용 패키지다

## 비목표

깨진 참조 수리는 감사 결과 0건이라 해당 없다. 프론트엔드 UI 개발과 rule 자체 변경은 다루지 않는다.

Closes #275
